### PR TITLE
Fix test for GetPartitionSize, and fix GetPartitionSize for GPT

### DIFF
--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -518,7 +518,8 @@ func (t *Table) GetPartitionSize(partition int) (int64, error) {
 		return 0, fmt.Errorf("Requested partition %d but only have %d partitions in table", partition, len(t.Partitions))
 	}
 
-	return int64(t.Partitions[partition-1].Size) * int64(t.LogicalSectorSize), nil
+	// size already is in Bytes
+	return int64(t.Partitions[partition-1].Size), nil
 }
 
 // GetPartitionStart returns the start position in bytes of a single partition

--- a/partition/gpt/table_test.go
+++ b/partition/gpt/table_test.go
@@ -366,13 +366,12 @@ func TestGetPartitionSize(t *testing.T) {
 	})
 	t.Run("valid", func(t *testing.T) {
 		table := GetValidTable()
-		maxPart := len(table.Partitions)
-		request := maxPart - 1
+		request := 1
 		size, err := table.GetPartitionSize(request)
 		if err != nil {
 			t.Errorf("Error was not nil")
 		}
-		expected := int64(table.Partitions[request].Size)
+		expected := int64(table.Partitions[request-1].Size)
 		if size != expected {
 			t.Errorf("Received size %d instead of %d", size, expected)
 		}


### PR DESCRIPTION
Fixes #10 

Two issues:

1. Test for gpt `GetPartitionSize()` was comparing sizes of partitions that have no size at all, so 0*anything still was 0, and test passed, even though it should have failed. Test now checks first partition, which has proper size.
2. gpt `GetPartitionSize()` was multiplying partition size by sector size, even though size already was in bytes.