### PR TITLE
Replace illegal characters in shortname with _

### DIFF
--- a/filesystem/iso9660/finalize.go
+++ b/filesystem/iso9660/finalize.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -844,6 +845,11 @@ func calculateShortnameExtension(name string) (string, string) {
 	// shortname and extension must be upper-case
 	shortname = strings.ToUpper(shortname)
 	extension = strings.ToUpper(extension)
+
+	// replace illegal characters in shortname and extension with _
+	re := regexp.MustCompile("[^A-Z0-9_]")
+	shortname = re.ReplaceAllString(shortname, "_")
+	extension = re.ReplaceAllString(extension, "_")
 
 	return shortname, extension
 }


### PR DESCRIPTION
When calculating the 8.3 filename we replace all characters
that are not [A-Z0-9_] with _

Signed-off-by: Darren Shepherd <darren@rancher.com>