### PR TITLE
Allowing MBR writeContents() to write successfully

### DIFF
--- a/partition/mbr/partition_internal_test.go
+++ b/partition/mbr/partition_internal_test.go
@@ -277,7 +277,7 @@ func TestWriteContents(t *testing.T) {
 			EndHead:       0,
 			EndSector:     2,
 			EndCylinder:   0,
-			Start:         partitionStart,
+			Start:         partitionStart / 512,
 			Size:          1,
 		}
 		// make a byte array that is too big
@@ -290,9 +290,9 @@ func TestWriteContents(t *testing.T) {
 				return len(b), nil
 			},
 		}
-		read, err := partition.writeContents(f, 512, 512, reader)
-		if read != 0 {
-			t.Errorf("Returned %d bytes read instead of 0", read)
+		written, err := partition.writeContents(f, 512, 512, reader)
+		if written != 512 {
+			t.Errorf("Returned %d bytes written instead of 512", written)
 		}
 		if err == nil {
 			t.Errorf("Returned nil error instead of actual errors")
@@ -305,6 +305,7 @@ func TestWriteContents(t *testing.T) {
 
 	t.Run("successful write", func(t *testing.T) {
 		size := 512000
+		sectorSize := size / 512
 		partition := Partition{
 			Bootable:      false,
 			StartHead:     0,
@@ -315,7 +316,7 @@ func TestWriteContents(t *testing.T) {
 			EndSector:     2,
 			EndCylinder:   0,
 			Start:         partitionStart,
-			Size:          uint32(size),
+			Size:          uint32(sectorSize),
 		}
 		b := make([]byte, size, size)
 		rand.Read(b)
@@ -332,7 +333,7 @@ func TestWriteContents(t *testing.T) {
 			t.Errorf("Returned %d bytes written instead of %d", written, size)
 		}
 		if err != nil {
-			t.Errorf("Returned error instead of nil")
+			t.Errorf("Returned error instead of nil: %v", err)
 			return
 		}
 		if bytes.Compare(b2, b) != 0 {

--- a/partition/mbr/partition_internal_test.go
+++ b/partition/mbr/partition_internal_test.go
@@ -277,7 +277,7 @@ func TestWriteContents(t *testing.T) {
 			EndHead:       0,
 			EndSector:     2,
 			EndCylinder:   0,
-			Start:         partitionStart / 512,
+			Start:         partitionStart,
 			Size:          1,
 		}
 		// make a byte array that is too big
@@ -290,6 +290,9 @@ func TestWriteContents(t *testing.T) {
 				return len(b), nil
 			},
 		}
+		// We have a size of 1 sector, or 512 bytes, but are trying to write 2*512.
+		// It should write the first and fail on the second so we expect an error,
+		// along with 512 bytes successfully written
 		written, err := partition.writeContents(f, 512, 512, reader)
 		if written != 512 {
 			t.Errorf("Returned %d bytes written instead of 512", written)

--- a/partition/mbr/partiton.go
+++ b/partition/mbr/partiton.go
@@ -111,6 +111,8 @@ func (p *Partition) writeContents(f util.File, logicalSectorSize, physicalSector
 	b := make([]byte, physicalSectorSize, physicalSectorSize)
 	// we start at the correct byte location
 	start := p.Start * uint32(logicalSectorSize)
+	size := p.Size * uint32(logicalSectorSize)
+
 	// loop in physical sector sizes
 	for {
 		read, err := contents.Read(b)
@@ -118,8 +120,8 @@ func (p *Partition) writeContents(f util.File, logicalSectorSize, physicalSector
 			return total, fmt.Errorf("Could not read contents to pass to partition: %v", err)
 		}
 		tmpTotal := uint64(read) + total
-		if uint32(tmpTotal) > p.Size {
-			return total, fmt.Errorf("Requested to write at least %d bytes to partition but maximum size is %d", tmpTotal, p.Size)
+		if uint32(tmpTotal) > size {
+			return total, fmt.Errorf("Requested to write at least %d bytes to partition but maximum size is %d", tmpTotal, size)
 		}
 		var written int
 		if read > 0 {
@@ -136,8 +138,8 @@ func (p *Partition) writeContents(f util.File, logicalSectorSize, physicalSector
 		}
 	}
 	// did the total written equal the size of the partition?
-	if total != uint64(p.Size) {
-		return total, fmt.Errorf("Write %d bytes to partition but actual size is %d", total, p.Size)
+	if total != uint64(size) {
+		return total, fmt.Errorf("Write %d bytes to partition but actual size is %d", total, size)
 	}
 	return total, nil
 }

--- a/partition/mbr/table_test.go
+++ b/partition/mbr/table_test.go
@@ -470,7 +470,7 @@ func TestWritePartitionContents(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		table := mbr.GetValidTable()
 		request := 0
-		size := table.Partitions[request].Size
+		size := table.Partitions[request].Size * uint32(table.LogicalSectorSize)
 		b := make([]byte, size, size)
 		rand.Read(b)
 		reader := bytes.NewReader(b)


### PR DESCRIPTION
MBR partition writeContents() was not checking against the number of bytes in the partition when checking size. Replicated logic from readContents() and updated unit tests.

Review carefully please as I needed to change more in the unit tests than I would have expected.