### PR TITLE
Only allow valid iso9660 block sizes

### DIFF
--- a/filesystem/iso9660/iso9660.go
+++ b/filesystem/iso9660/iso9660.go
@@ -465,9 +465,9 @@ func (fs *FileSystem) readDirectory(p string) ([]*directoryEntry, error) {
 
 func validateBlocksize(blocksize int64) error {
 	switch blocksize {
-	case 0, 512, 1024, 2048, 4096, 8192:
+	case 0, 2048, 4096, 8192:
 		return nil
 	default:
-		return fmt.Errorf("blocksize for ISO9660 must be one of 500, 512, 1024, 2048, 4096, 8192")
+		return fmt.Errorf("blocksize for ISO9660 must be one of 2048, 4096, 8192")
 	}
 }

--- a/filesystem/iso9660/iso9660_test.go
+++ b/filesystem/iso9660/iso9660_test.go
@@ -173,7 +173,7 @@ func TestISO9660Read(t *testing.T) {
 	}{
 		{500, 6000, -1, nil, fmt.Errorf("blocksize for ISO9660 must be")},
 		{513, 6000, -1, nil, fmt.Errorf("blocksize for ISO9660 must be")},
-		{512, iso9660.MaxBlocks*2048 + 10000, -1, nil, fmt.Errorf("requested size is larger than maximum allowed ISO9660 size")},
+		{512, iso9660.MaxBlocks*2048 + 10000, -1, nil, fmt.Errorf("blocksize for ISO9660 must be")},
 		{2048, 10000000, -1, &iso9660.FileSystem{}, nil},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The original iso9660 implementation allowed block sizes of 512, 1024, 2048, etc. However, only exponents of 2048 are allowed: 2048, 4096, 8192, etc. This corrects it and fixes the tests