### PR TITLE
introduce OpenWithMode()

### DIFF
--- a/diskfs_test.go
+++ b/diskfs_test.go
@@ -66,16 +66,31 @@ func TestOpen(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		disk, err := diskfs.Open(tt.path)
+		d, err := diskfs.Open(tt.path)
 		msg := fmt.Sprintf("Open(%s)", tt.path)
 		switch {
 		case (err == nil && tt.err != nil) || (err != nil && tt.err == nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
 			t.Errorf("%s: mismatched errors, actual %v expected %v", msg, err, tt.err)
-		case (disk == nil && tt.disk != nil) || (disk != nil && tt.disk == nil):
-			t.Errorf("%s: mismatched disk, actual %v expected %v", msg, disk, tt.disk)
-		case disk != nil && (disk.LogicalBlocksize != tt.disk.LogicalBlocksize || disk.PhysicalBlocksize != tt.disk.PhysicalBlocksize || disk.Size != tt.disk.Size || disk.Type != tt.disk.Type):
+		case (d == nil && tt.disk != nil) || (d != nil && tt.disk == nil):
+			t.Errorf("%s: mismatched disk, actual %v expected %v", msg, d, tt.disk)
+		case d != nil && (d.LogicalBlocksize != tt.disk.LogicalBlocksize || d.PhysicalBlocksize != tt.disk.PhysicalBlocksize || d.Size != tt.disk.Size || d.Type != tt.disk.Type):
 			t.Errorf("%s: mismatched disk, actual then expected", msg)
-			t.Logf("%v", disk)
+			t.Logf("%v", d)
+			t.Logf("%v", tt.disk)
+		}
+	}
+
+	for _, tt := range tests {
+		d, err := diskfs.OpenWithMode(tt.path, diskfs.ReadOnly)
+		msg := fmt.Sprintf("Open(%s)", tt.path)
+		switch {
+		case (err == nil && tt.err != nil) || (err != nil && tt.err == nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
+			t.Errorf("%s: mismatched errors, actual %v expected %v", msg, err, tt.err)
+		case (d == nil && tt.disk != nil) || (d != nil && tt.disk == nil):
+			t.Errorf("%s: mismatched disk, actual %v expected %v", msg, d, tt.disk)
+		case d != nil && (d.LogicalBlocksize != tt.disk.LogicalBlocksize || d.PhysicalBlocksize != tt.disk.PhysicalBlocksize || d.Size != tt.disk.Size || d.Type != tt.disk.Type):
+			t.Errorf("%s: mismatched disk, actual then expected", msg)
+			t.Logf("%v", d)
 			t.Logf("%v", tt.disk)
 		}
 	}


### PR DESCRIPTION
Here I propose a new function to open a disk device with a user selected mode: the OpenWithMode() function.

With this function, clients are able to execute read-only operations in situations where the device is already open for write. For instance, LVM physical volumes will already be open for write and then this library does not support this case which is a very common case these days.
Clients can also make use of the library in a safer mode when just reading the current disk partitioning format is required and then make sure no change to the disk will be allowed.

The proposed changes adds a new flag to the Disk structure to indicate it is writable or not. This flag is used to explicitly fail any operation which would modify the disk if it was opened in read-only mode.

The original interface is not broken and then existing clients are not impacted.


* introduce OpenWithMode()

Signed-off-by: Guilherme Magalhaes <guilherme.magalhaes@hpe.com>

* add tests with readonly disks for write operations

Signed-off-by: Guilherme Magalhaes <guilherme.magalhaes@hpe.com>