### PR TITLE
fix error message in OpenWithMode()

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -140,6 +140,18 @@ const (
 	ReadWriteExclusive
 )
 
+// OpenModeOption.String()
+func (d OpenModeOption) String() string {
+	switch d {
+	case ReadOnly:
+		return "read-only"
+	case ReadWriteExclusive:
+		return "read-write exclusive"
+	default:
+		return "unknown"
+	}
+}
+
 var openModeOptions = map[OpenModeOption]int{
 	ReadOnly:           os.O_RDONLY,
 	ReadWriteExclusive: os.O_RDWR | os.O_EXCL,
@@ -255,7 +267,7 @@ func OpenWithMode(device string, mode OpenModeOption) (*disk.Disk, error) {
 	}
 	f, err := os.OpenFile(device, m, 0600)
 	if err != nil {
-		return nil, fmt.Errorf("Could not open device %s exclusively for writing", device)
+		return nil, fmt.Errorf("Could not open device %s with mode %v: %v", device, mode, err)
 	}
 	// return our disk
 	return initDisk(f, mode)

--- a/diskfs.go
+++ b/diskfs.go
@@ -141,8 +141,8 @@ const (
 )
 
 // OpenModeOption.String()
-func (d OpenModeOption) String() string {
-	switch d {
+func (m OpenModeOption) String() string {
+	switch m {
 	case ReadOnly:
 		return "read-only"
 	case ReadWriteExclusive:


### PR DESCRIPTION
Please consider this fix for a misleading error message in the OpenWithMode() function.
Now it correctly prints the selected file open mode and also wraps the lower level error.

Signed-off-by: Guilherme Magalhaes <guilherme.magalhaes@hpe.com>