### PR TITLE
Handle disks larger than 4 GB

### DIFF
--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -296,11 +296,11 @@ func Create(f util.File, size int64, start int64, blocksize int64, volumeLabel s
 
 	// be sure to zero out the root cluster, so we do not pick up phantom
 	// entries.
-	clusterStart := uint32(fs.start) + fs.dataStart
+	clusterStart := fs.start + int64(fs.dataStart)
 	// length of cluster in bytes
 	tmpb := make([]byte, fs.bytesPerCluster)
 	// zero out the root directory cluster
-	written, err := f.WriteAt(tmpb, int64(clusterStart))
+	written, err := f.WriteAt(tmpb, clusterStart)
 	if err != nil {
 		return nil, fmt.Errorf("failed to zero out root directory: %v", err)
 	}
@@ -581,11 +581,11 @@ func (fs *FileSystem) readDirectory(dir *Directory) ([]*directoryEntry, error) {
 	b := make([]byte, 0, byteCount)
 	for _, cluster := range clusterList {
 		// bytes where the cluster starts
-		clusterStart := uint32(fs.start) + fs.dataStart + (cluster-2)*uint32(fs.bytesPerCluster)
+		clusterStart := fs.start + int64(fs.dataStart) + int64(cluster-2)*int64(fs.bytesPerCluster)
 		// length of cluster in bytes
 		tmpb := make([]byte, fs.bytesPerCluster, fs.bytesPerCluster)
 		// read the entire cluster
-		fs.file.ReadAt(tmpb, int64(clusterStart))
+		fs.file.ReadAt(tmpb, clusterStart)
 		b = append(b, tmpb...)
 	}
 	// get the directory
@@ -631,9 +631,9 @@ func (fs *FileSystem) writeDirectoryEntries(dir *Directory) error {
 	// read the data from all of the cluster entries in the list
 	for i, cluster := range clusterList {
 		// bytes where the cluster starts
-		clusterStart := uint32(fs.start) + fs.dataStart + (cluster-2)*uint32(fs.bytesPerCluster)
+		clusterStart := fs.start + int64(fs.dataStart) + int64(cluster-2)*int64(fs.bytesPerCluster)
 		bStart := i * fs.bytesPerCluster
-		written, err := fs.file.WriteAt(b[bStart:bStart+fs.bytesPerCluster], int64(clusterStart))
+		written, err := fs.file.WriteAt(b[bStart:bStart+fs.bytesPerCluster], clusterStart)
 		if err != nil {
 			return fmt.Errorf("Error writing directory entries: %v", err)
 		}


### PR DESCRIPTION
Fixes #48 

Problem was that the number of sectors in a fat32 is a uint32 (max 4GB), so the parameter blocks used a uint32 for the data start offset, which we use to calculate where inside the partition to write things.

When the partition is inside a disk (block device or image), you need to add the offset from, the disk start. Since the whole disk can be much larger than the max of a uint32; go's `WriteAt/ReadAt` take an int64.

When doing the calculation, you need to convert from the uint32 to the int64, while doing calculations en route. The initial math (reasons lost to the mists of time) converted parameters to a uint32 (matching the `dataStart` parameter) to do the math, then up to `int64` to do the `WriteAt()`. 

The correct thing (provided by this PR) is to upconvert everything to an `int64` and then do the math, otherwise, if one of your parameters (e.g. partition start) is an `int64` but bigger than the maximum of `uint32`, you will lose data. Hence #48 