### PR TITLE
fix block device sizing

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -60,7 +60,7 @@ func (d *Disk) Partition(table partition.Table) error {
 		return errIncorrectOpenMode
 	}
 	// fill in the uuid
-	err := table.Write(d.File, d.Info.Size())
+	err := table.Write(d.File, d.Size)
 	if err != nil {
 		return fmt.Errorf("Failed to write partition table: %v", err)
 	}

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -111,6 +111,7 @@ func TestPartition(t *testing.T) {
 			PhysicalBlocksize: 512,
 			Info:              fileInfo,
 			Writable:          true,
+			Size:              fileInfo.Size(),
 		}
 		// this is partition start and end in sectors, not bytes
 		sectorSize := 512


### PR DESCRIPTION
Fixes #52 

`FileInfo.Size()` works correctly when the disk is a disk image. However, when it is an actual block device, it returns 0. This is _precisely_ why we have [this code](https://github.com/diskfs/go-diskfs/blob/3bd1f70075f0eed12a5e50c1c38c39b94c755bd6/diskfs.go#L192-L205), to calculate it for a block device. We then forget to take advantage of the saved size as `Disk.Size`. 

This uses the correct sizing.