### PR TITLE
force kernel to reread partition table

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -36,8 +36,6 @@ const (
 	File Type = iota
 	// Device is an OS-managed block device
 	Device
-	// blkRRPart is the ioctl request to re-read the partition table
-	blkRRPart = 0x0000125F
 )
 
 var (

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -1,0 +1,21 @@
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package disk
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+)
+
+// ReReadPartitionTable forces the kernel to re-read the partition table
+// on the disk.
+//
+// It is done via an ioctl call with request as BLKRRPART.
+func (d *Disk) ReReadPartitionTable() error {
+	fd := d.File.Fd()
+	_, err := unix.IoctlGetInt(int(fd), unix.BLKRRPART)
+	if err != nil {
+		return fmt.Errorf("Unable to re-read partition table: %v", err)
+	}
+	return nil
+}

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -1,0 +1,10 @@
+package disk
+
+// ReReadPartitionTable is used to re-read the partition table
+// on the disk.
+//
+// In windows machine, force re-read is not done. The method returns nil when
+// invoked
+func (d *Disk) ReReadPartitionTable() error {
+	return nil
+}


### PR DESCRIPTION
force kernel to reread partition table after successfully writing a partition table to the disk. This is done by an ioctl call with BLKRRPART request

Fixes : #56 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>