### PR TITLE
Fix GPTProtective partition type (0xee) for hybrid/protective MBRs

### DIFF
--- a/partition/mbr/types.go
+++ b/partition/mbr/types.go
@@ -26,7 +26,7 @@ const (
 	MacOSXBoot    Type = 0xab
 	HFS           Type = 0xaf
 	Solaris8Boot  Type = 0xbe
-	GPTProtective Type = 0xef
+	GPTProtective Type = 0xee
 	EFISystem     Type = 0xef
 	VMWareFS      Type = 0xfb
 	VMWareSwap    Type = 0xfc


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/Partition_type#PID_EEh
```
0xEE GPT protective MBR
0xEF EFI system partition
```