### PR TITLE
Fix GPT partition reading

### DIFF
--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -264,7 +264,7 @@ func TestReadPartitionContents(t *testing.T) {
 		partitionSize := uint64(1000)
 		table := &gpt.Table{
 			Partitions: []*gpt.Partition{
-				{Start: partitionStart, Size: partitionSize},
+				{Start: partitionStart, Size: partitionSize * 512},
 			},
 			LogicalSectorSize: 512,
 		}

--- a/partition/gpt/partiton.go
+++ b/partition/gpt/partiton.go
@@ -195,13 +195,13 @@ func (p *Partition) WriteContents(f util.File, contents io.Reader) (uint64, erro
 // ReadContents reads the contents of the partition into a writer
 // streams the entire partition to the writer
 func (p *Partition) ReadContents(f util.File, out io.Writer) (int64, error) {
-	pss, lss := p.sectorSizes()
+	pss, _ := p.sectorSizes()
 	total := int64(0)
 	// chunks of physical sector size for efficient writing
 	b := make([]byte, pss, pss)
 	// we start at the correct byte location
-	start := p.Start * uint64(lss)
-	size := p.Size * uint64(lss)
+	start := p.GetStart()
+	size := p.GetSize()
 
 	// loop in physical sector sizes
 	for {


### PR DESCRIPTION
The Partition.Size attribute of the gpt packages is already in bytes.
Use GetSize() and GetStart() to avoid byte/sector confusion.