### PR TITLE
Correctly write backup blocks

### DIFF
--- a/filesystem/fat32/dos71bpb.go
+++ b/filesystem/fat32/dos71bpb.go
@@ -42,7 +42,7 @@ type dos71EBPB struct {
 	version               fatVersion // Version is the version of the FAT, must be 0
 	rootDirectoryCluster  uint32     // RootDirectoryCluster is the cluster containing the filesystem root directory, normally 2
 	fsInformationSector   uint16     // FSInformationSector holds the sector which contains the primary DOS 7.1 Filesystem Information Cluster
-	backupFSInfoSector    uint16     // BackupFSInfoSector holds the sector which contains the backup DOS 7.1 Filesystem Information Cluster
+	backupBootSector      uint16     // BackupBootSector holds the sector which contains the backup boot sector and following FSIS sectors
 	bootFileName          [12]byte   // BootFileName is reserved and should be all 0x00
 	driveNumber           uint8      // DriveNumber is the code for the relative position and type of this drive in the system
 	reservedFlags         uint8      // ReservedFlags are flags used by the operating system and/or BIOS for various purposes, e.g. Windows NT CHKDSK status, OS/2 desired drive letter, etc.
@@ -65,7 +65,7 @@ func (bpb *dos71EBPB) equal(a *dos71EBPB) bool {
 		bpb.version == a.version &&
 		bpb.rootDirectoryCluster == a.rootDirectoryCluster &&
 		bpb.fsInformationSector == a.fsInformationSector &&
-		bpb.backupFSInfoSector == a.backupFSInfoSector &&
+		bpb.backupBootSector == a.backupBootSector &&
 		bpb.bootFileName == a.bootFileName &&
 		bpb.driveNumber == a.driveNumber &&
 		bpb.reservedFlags == a.reservedFlags &&
@@ -101,7 +101,7 @@ func dos71EBPBFromBytes(b []byte) (*dos71EBPB, int, error) {
 	bpb.version = fatVersion0
 	bpb.rootDirectoryCluster = binary.LittleEndian.Uint32(b[33:37])
 	bpb.fsInformationSector = binary.LittleEndian.Uint16(b[37:39])
-	bpb.backupFSInfoSector = binary.LittleEndian.Uint16(b[39:41])
+	bpb.backupBootSector = binary.LittleEndian.Uint16(b[39:41])
 	bootFileName := b[41:53]
 	copy(bpb.bootFileName[:], bootFileName)
 	bpb.driveNumber = uint8(b[53])
@@ -173,7 +173,7 @@ func (bpb *dos71EBPB) toBytes() ([]byte, error) {
 	binary.LittleEndian.PutUint16(b[31:33], uint16(bpb.version))
 	binary.LittleEndian.PutUint32(b[33:37], bpb.rootDirectoryCluster)
 	binary.LittleEndian.PutUint16(b[37:39], bpb.fsInformationSector)
-	binary.LittleEndian.PutUint16(b[39:41], bpb.backupFSInfoSector)
+	binary.LittleEndian.PutUint16(b[39:41], bpb.backupBootSector)
 	copy(b[41:53], bpb.bootFileName[:])
 	b[53] = bpb.driveNumber
 	b[54] = bpb.reservedFlags

--- a/filesystem/fat32/dos71bpb_internal_test.go
+++ b/filesystem/fat32/dos71bpb_internal_test.go
@@ -17,7 +17,7 @@ func getValidDos71EBPB() *dos71EBPB {
 		version:               0,
 		rootDirectoryCluster:  2,
 		fsInformationSector:   1,
-		backupFSInfoSector:    6,
+		backupBootSector:      6,
 		bootFileName:          [12]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		driveNumber:           128,
 		reservedFlags:         0x00,

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -106,7 +106,7 @@ func Create(f util.File, size int64, start int64, blocksize int64, volumeLabel s
 	volid := uint32(now.Unix()<<20 | (now.UnixNano() / 1000000))
 
 	fsisPrimarySector := uint16(1)
-	fsisBackupSector := uint16(6)
+	backupBootSector := uint16(6)
 
 	/*
 		size calculations
@@ -191,7 +191,7 @@ func Create(f util.File, size int64, start int64, blocksize int64, volumeLabel s
 		version:               fatVersion0,
 		rootDirectoryCluster:  2,
 		fsInformationSector:   fsisPrimarySector,
-		backupFSInfoSector:    fsisBackupSector,
+		backupBootSector:      backupBootSector,
 		bootFileName:          [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		extendedBootSignature: longDos71EBPB,
 		volumeSerialNumber:    volid,
@@ -229,8 +229,8 @@ func Create(f util.File, size int64, start int64, blocksize int64, volumeLabel s
 	}
 
 	// write backup to the file
-	if fsisBackupSector > 0 {
-		count, err = f.WriteAt(b, int64(fsisBackupSector)*int64(SectorSize512)+int64(start))
+	if backupBootSector > 0 {
+		count, err = f.WriteAt(b, int64(backupBootSector)*int64(SectorSize512)+int64(start))
 		if err != nil {
 			return nil, fmt.Errorf("Error writing MS-DOS Boot Sector to disk: %v", err)
 		}
@@ -254,8 +254,8 @@ func Create(f util.File, size int64, start int64, blocksize int64, volumeLabel s
 	fsisPrimary := int64(fsisPrimarySector * uint16(SectorSize512))
 
 	f.WriteAt(fsisBytes, fsisPrimary+int64(start))
-	if fsisBackupSector > 0 {
-		f.WriteAt(fsisBytes, int64(fsisBackupSector+1)*int64(SectorSize512)+int64(start))
+	if backupBootSector > 0 {
+		f.WriteAt(fsisBytes, int64(backupBootSector+1)*int64(SectorSize512)+int64(start))
 	}
 
 	// write FAT tables
@@ -856,11 +856,11 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 		return nil, fmt.Errorf("Could not create a valid byte stream for a FAT32 Filesystem Information Sector: %v", err)
 	}
 	fsisPrimary := fs.bootSector.biosParameterBlock.fsInformationSector
-	fsisBackup := fs.bootSector.biosParameterBlock.backupFSInfoSector
+	backupBootSector := fs.bootSector.biosParameterBlock.backupBootSector
 
 	fs.file.WriteAt(fsisBytes, int64(fsisPrimary)*int64(SectorSize512)+fs.start)
-	if fsisBackup > 0 {
-		fs.file.WriteAt(fsisBytes, int64(fsisBackup+1)*int64(SectorSize512)+fs.start)
+	if backupBootSector > 0 {
+		fs.file.WriteAt(fsisBytes, int64(backupBootSector+1)*int64(SectorSize512)+fs.start)
 	}
 
 	// return all of the clusters

--- a/filesystem/fat32/fat32_internal_test.go
+++ b/filesystem/fat32/fat32_internal_test.go
@@ -67,7 +67,7 @@ func getValidFat32FSSmall() *FileSystem {
 		bootSector: msDosBootSector{
 			biosParameterBlock: &dos71EBPB{
 				fsInformationSector: 2,
-				backupFSInfoSector:  6,
+				backupBootSector:    6,
 				dos331BPB: &dos331BPB{
 					dos20BPB: &dos20BPB{
 						reservedSectors:   32,


### PR DESCRIPTION
Fixes fsck.vfat complais about the backup blocks:
- boot sector is copied to the backup block location
- filesystem information is packed into the next logical block
- fat backup is written alongside the primary copy

fsck.vfat does not complain about these issues after applying the patch