### PR TITLE
Fix allocateSpace if previous points to the beginning of a chain

### DIFF
--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -789,6 +789,8 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 		}
 		originalClusterCount := len(clusters)
 		extraClusterCount = count - originalClusterCount
+		// make sure that previous is the last cluster of the previous chain
+		previous = clusters[len(clusters)-1]
 	}
 
 	// what id we do not need to allocate any?


### PR DESCRIPTION
Allocate space will link the old chain with the new chain. This can only
work if previous is pointing to the last cluster of the privious chain.