### PR TITLE
Fix cluster location of .. directory entry

### DIFF
--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -734,11 +734,16 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, []*di
 					return nil, nil, fmt.Errorf("Failed to create subdirectory %s", "/"+strings.Join(paths[0:i+1], "/"))
 				}
 				// make a basic entry for the new subdir
+				parentDirectoryCluster := currentDir.clusterLocation
+				if parentDirectoryCluster == 2 {
+					// references to the root directory (cluster 2) must be stored as 0
+					parentDirectoryCluster = 0
+				}
 				dir := &Directory{
 					directoryEntry: directoryEntry{clusterLocation: subdirEntry.clusterLocation},
 					entries: []*directoryEntry{
 						{filenameShort: ".", isSubdirectory: true, clusterLocation: subdirEntry.clusterLocation},
-						{filenameShort: "..", isSubdirectory: true, clusterLocation: currentDir.clusterLocation},
+						{filenameShort: "..", isSubdirectory: true, clusterLocation: parentDirectoryCluster},
 					},
 				}
 				// write the new directory entries to disk


### PR DESCRIPTION
The cluster location of parent directory entries (`..`) pointing to the root directory (`/`) must be 0, not 2. `fsck.vfat` complains about this.

Currently based on #64 for testing purposes (large root folder)