### PR TITLE
separate windows and unix for block devices

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -110,7 +110,6 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 
 	"github.com/diskfs/go-diskfs/disk"
 )
@@ -301,22 +300,4 @@ func Create(device string, size int64, format Format) (*disk.Disk, error) {
 	}
 	// return our disk
 	return initDisk(f, ReadWriteExclusive)
-}
-
-// to get the logical and physical sector sizes
-func getSectorSizes(f *os.File) (int64, int64, error) {
-	/*
-		ioctl(fd, BLKBSZGET, &physicalsectsize);
-
-	*/
-	fd := f.Fd()
-	logicalSectorSize, err := unix.IoctlGetInt(int(fd), blksszGet)
-	if err != nil {
-		return 0, 0, fmt.Errorf("Unable to get device logical sector size: %v", err)
-	}
-	physicalSectorSize, err := unix.IoctlGetInt(int(fd), blkbszGet)
-	if err != nil {
-		return 0, 0, fmt.Errorf("Unable to get device physical sector size: %v", err)
-	}
-	return int64(logicalSectorSize), int64(physicalSectorSize), nil
 }

--- a/diskfs_unix.go
+++ b/diskfs_unix.go
@@ -1,0 +1,26 @@
+package diskfs
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// getSectorSizes get the logical and physical sector sizes for a block device
+func getSectorSizes(f *os.File) (int64, int64, error) {
+	/*
+		ioctl(fd, BLKBSZGET, &physicalsectsize);
+
+	*/
+	fd := f.Fd()
+	logicalSectorSize, err := unix.IoctlGetInt(int(fd), blksszGet)
+	if err != nil {
+		return 0, 0, fmt.Errorf("Unable to get device logical sector size: %v", err)
+	}
+	physicalSectorSize, err := unix.IoctlGetInt(int(fd), blkbszGet)
+	if err != nil {
+		return 0, 0, fmt.Errorf("Unable to get device physical sector size: %v", err)
+	}
+	return int64(logicalSectorSize), int64(physicalSectorSize), nil
+}

--- a/diskfs_windows.go
+++ b/diskfs_windows.go
@@ -1,0 +1,10 @@
+package diskfs
+
+import (
+	"errors"
+)
+
+// getSectorSizes get the logical and physical sector sizes for a block device
+func getSectorSizes(f *os.File) (int64, int64, error) {
+	return 0, 0, errors.New("block devices not supported on windows")
+}


### PR DESCRIPTION
This doesn't get block devices working on Windows, but it allows everything else to work, which is a step forward.

We need to figure out how to read/write block devices directly on Windows.

Fixes #75 