### PR TITLE
Finish reading the entire file in iso9660

### DIFF
--- a/filesystem/iso9660/common_internal_test.go
+++ b/filesystem/iso9660/common_internal_test.go
@@ -46,3 +46,32 @@ func GetTestFile(t *testing.T) (*File, string) {
 		offset:         0,
 	}, "README\n"
 }
+
+func GetLargeTestFile(t *testing.T) (*File, uint32) {
+	// FileSystem implements the FileSystem interface
+	file, err := os.Open(ISO9660File)
+	if err != nil {
+		t.Errorf("Could not read ISO9660 test file %s: %v", ISO9660File, err)
+	}
+	fs := &FileSystem{
+		workspace: "",
+		size:      ISO9660Size,
+		start:     0,
+		file:      file,
+		blocksize: 2048,
+	}
+	de := &directoryEntry{
+		extAttrSize: 0,
+		location:    38,
+		size:        5242880,
+		creation:    time.Now(),
+		filesystem:  fs,
+		filename:    "LARGEFIL.;1",
+	}
+	return &File{
+		directoryEntry: de,
+		isReadWrite:    false,
+		isAppend:       false,
+		offset:         0,
+	}, de.size
+}

--- a/filesystem/iso9660/file.go
+++ b/filesystem/iso9660/file.go
@@ -46,7 +46,7 @@ func (fl *File) Read(b []byte) (int, error) {
 
 	fl.offset = fl.offset + int64(maxRead)
 	var retErr error
-	if fl.offset >= int64(size) {
+	if fl.offset >= int64(fl.size) {
 		retErr = io.EOF
 	}
 	return maxRead, retErr

--- a/filesystem/iso9660/file_test.go
+++ b/filesystem/iso9660/file_test.go
@@ -2,6 +2,7 @@ package iso9660_test
 
 import (
 	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/diskfs/go-diskfs/filesystem/iso9660"
@@ -23,6 +24,18 @@ func TestFileRead(t *testing.T) {
 	bString := string(b[:read])
 	if bString != content {
 		t.Errorf("Mismatched content:\nActual: '%s'\nExpected: '%s'", bString, content)
+	}
+}
+
+func TestLargeFileCopy(t *testing.T) {
+	f, size := iso9660.GetLargeTestFile(t)
+
+	copied, err := io.Copy(ioutil.Discard, f)
+	if err != nil {
+		t.Errorf("received unexpected error when copying: %v", err)
+	}
+	if copied != int64(size) {
+		t.Errorf("copied %d bytes instead of expected %d", copied, size)
 	}
 }
 


### PR DESCRIPTION
`size` here is the amount we have left to write. To determine if we
are done, we need to compare the new offset to the total size of
the file.

Without this fix we would always bail at around halfway
(+/- the buffer size) through any file larger than the buffer size.