### PR TITLE
Remove the iso workspace after running Finalize

### DIFF
--- a/filesystem/iso9660/finalize.go
+++ b/filesystem/iso9660/finalize.go
@@ -713,6 +713,8 @@ func (fs *FileSystem) Finalize(options FinalizeOptions) error {
 	b = terminator.toBytes()
 	f.WriteAt(b, int64(location)*int64(blocksize))
 
+	_ = os.RemoveAll(fs.workspace)
+
 	// finish by setting as finalized
 	fs.workspace = ""
 	return nil

--- a/filesystem/iso9660/finalize_test.go
+++ b/filesystem/iso9660/finalize_test.go
@@ -328,10 +328,17 @@ func TestFinalizeRockRidge(t *testing.T) {
 			}
 		}
 
+		workspace := fs.Workspace()
+
 		err = fs.Finalize(iso9660.FinalizeOptions{RockRidge: true})
 		if err != nil {
 			t.Fatal("Unexpected error fs.Finalize({RockRidge: true})", err)
 		}
+
+		if _, err := os.Stat(workspace); !os.IsNotExist(err) {
+			t.Fatalf("Workspace dir %s should be removed after finalizing", workspace)
+		}
+
 		// now need to check contents
 		fi, err := f.Stat()
 		if err != nil {


### PR DESCRIPTION
Previously this directory which contained all the files in the iso
would be left in the temp directory.

Fixes #90