### PR TITLE
fix(filesystem/iso9660): fix bug when compare null bytes

### DIFF
--- a/filesystem/iso9660/volume_descriptor.go
+++ b/filesystem/iso9660/volume_descriptor.go
@@ -234,13 +234,13 @@ func parsePrimaryVolumeDescriptor(b []byte) (*primaryVolumeDescriptor, error) {
 	var expiration, effective time.Time
 	expirationBytes := b[847 : 847+17]
 	effectiveBytes := b[864 : 864+17]
-	if bytes.Compare(expirationBytes, nullBytes) != 0 {
+	if bytes.Compare(expirationBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
 		expiration, err = decBytesToTime(expirationBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert expiration date/time from bytes: %v", err)
 		}
 	}
-	if bytes.Compare(effectiveBytes, nullBytes) != 0 {
+	if bytes.Compare(effectiveBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
 		effective, err = decBytesToTime(effectiveBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert effective date/time from bytes: %v", err)
@@ -335,13 +335,13 @@ func parseSupplementaryVolumeDescriptor(b []byte) (*supplementaryVolumeDescripto
 	var expiration, effective time.Time
 	expirationBytes := b[847 : 847+17]
 	effectiveBytes := b[864 : 864+17]
-	if bytes.Compare(expirationBytes, nullBytes) != 0 {
+	if bytes.Compare(expirationBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
 		expiration, err = decBytesToTime(expirationBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert expiration date/time from bytes: %v", err)
 		}
 	}
-	if bytes.Compare(effectiveBytes, nullBytes) != 0 {
+	if bytes.Compare(effectiveBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
 		effective, err = decBytesToTime(effectiveBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert effective date/time from bytes: %v", err)

--- a/filesystem/iso9660/volume_descriptor.go
+++ b/filesystem/iso9660/volume_descriptor.go
@@ -231,16 +231,17 @@ func parsePrimaryVolumeDescriptor(b []byte) (*primaryVolumeDescriptor, error) {
 	}
 	// expiration can be never
 	nullBytes := []byte{48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 0}
+	nullBytesAlt := bytes.Repeat([]byte{0}, len(nullBytes))
 	var expiration, effective time.Time
 	expirationBytes := b[847 : 847+17]
 	effectiveBytes := b[864 : 864+17]
-	if bytes.Compare(expirationBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
+	if bytes.Compare(expirationBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, nullBytesAlt) != 0 {
 		expiration, err = decBytesToTime(expirationBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert expiration date/time from bytes: %v", err)
 		}
 	}
-	if bytes.Compare(effectiveBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
+	if bytes.Compare(effectiveBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, nullBytesAlt) != 0 {
 		effective, err = decBytesToTime(effectiveBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert effective date/time from bytes: %v", err)
@@ -332,16 +333,17 @@ func parseSupplementaryVolumeDescriptor(b []byte) (*supplementaryVolumeDescripto
 	}
 	// expiration can be never
 	nullBytes := []byte{48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 0}
+	nullBytesAlt := bytes.Repeat([]byte{0}, len(nullBytes))
 	var expiration, effective time.Time
 	expirationBytes := b[847 : 847+17]
 	effectiveBytes := b[864 : 864+17]
-	if bytes.Compare(expirationBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
+	if bytes.Compare(expirationBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, nullBytesAlt) != 0 {
 		expiration, err = decBytesToTime(expirationBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert expiration date/time from bytes: %v", err)
 		}
 	}
-	if bytes.Compare(effectiveBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, bytes.Repeat([]byte{0}, len(nullBytes))) != 0 {
+	if bytes.Compare(effectiveBytes, nullBytes) != 0 && bytes.Compare(expirationBytes, nullBytesAlt) != 0 {
 		effective, err = decBytesToTime(effectiveBytes)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to convert effective date/time from bytes: %v", err)


### PR DESCRIPTION
"Unable to convert expiration date/time from bytes" was raised when parse some specific iso9660 images, eg:

https://mirrors.tuna.tsinghua.edu.cn/ubuntu-releases/xenial/ubuntu-16.04.7-server-amd64.iso