### PR TITLE
Add iso file Location() function

### DIFF
--- a/examples/iso_info.go
+++ b/examples/iso_info.go
@@ -1,0 +1,55 @@
+package examples
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/filesystem"
+	"github.com/diskfs/go-diskfs/filesystem/iso9660"
+)
+
+func PrintIsoInfo(isoPath string) {
+	disk, err := diskfs.Open(isoPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fs, err := disk.GetFilesystem(0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = fileInfoFor("/", fs)
+	if err != nil {
+		log.Fatalf("Failed to get file info: %s\n", err)
+	}
+}
+
+func fileInfoFor(path string, fs filesystem.FileSystem) error {
+	files, err := fs.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		fullPath := filepath.Join(path, file.Name())
+		if file.IsDir() {
+			err = fileInfoFor(fullPath, fs)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		isoFile, err := fs.OpenFile(fullPath, os.O_RDONLY)
+		if err != nil {
+			fmt.Printf("Failed to open file %s: %v\n", fullPath, err)
+			continue
+		}
+
+		myFile := isoFile.(*iso9660.File)
+		fmt.Printf("%s\n Size: %d\n Location: %d\n\n", fullPath, file.Size(), myFile.Location())
+	}
+	return nil
+}

--- a/filesystem/iso9660/file.go
+++ b/filesystem/iso9660/file.go
@@ -75,3 +75,7 @@ func (fl *File) Seek(offset int64, whence int) (int64, error) {
 	fl.offset = newOffset
 	return fl.offset, nil
 }
+
+func (fl *File) Location() uint32 {
+	return fl.location
+}


### PR DESCRIPTION
Fixes #92

With this I can get the basic info I would get from `isoinfo` which is the size and location.

Here's an example program:
```go
package main

import (
	"fmt"
	"os"
	"path/filepath"

	"github.com/diskfs/go-diskfs"
	"github.com/diskfs/go-diskfs/filesystem"
	"github.com/diskfs/go-diskfs/filesystem/iso9660"
)

func main() {
	disk, err := diskfs.Open("test.iso")
	if err != nil {
		fmt.Println(err)
		return
	}
	fs, err := disk.GetFilesystem(0)
	if err != nil {
		fmt.Println(err)
		return
	}

	err = fileInfoFor("/", fs)
	if err != nil {
		fmt.Printf("Failed to get file infos: %s\n", err)
	}
}

func fileInfoFor(path string, fs filesystem.FileSystem) error {
	files, err := fs.ReadDir(path)
	if err != nil {
		return err
	}

	for _, file := range files {
		fullPath := filepath.Join(path, file.Name())
		if file.IsDir() {
			err = fileInfoFor(fullPath, fs)
			if err != nil {
				return err
			}
			continue
		}
		isoFile, err := fs.OpenFile(fullPath, os.O_RDONLY)
		if err != nil {
			fmt.Printf("Failed to open file %s: %v\n", fullPath, err)
			continue
		}

		myFile := isoFile.(*iso9660.File)
		fmt.Printf("%s\n Size: %d\n Location: %d\n\n", fullPath, file.Size(), myFile.Location())
	}
	return nil
}
```