### PR TITLE
Allow providing a workspace in iso9660.Create

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -131,6 +131,7 @@ type FilesystemSpec struct {
 	Partition   int
 	FSType      filesystem.Type
 	VolumeLabel string
+	WorkDir     string
 }
 
 // CreateFilesystem creates a filesystem on a disk image, the equivalent of mkfs.
@@ -176,7 +177,7 @@ func (d *Disk) CreateFilesystem(spec FilesystemSpec) (filesystem.FileSystem, err
 	case filesystem.TypeFat32:
 		return fat32.Create(d.File, size, start, d.LogicalBlocksize, spec.VolumeLabel)
 	case filesystem.TypeISO9660:
-		return iso9660.Create(d.File, size, start, d.LogicalBlocksize)
+		return iso9660.Create(d.File, size, start, d.LogicalBlocksize, spec.WorkDir)
 	default:
 		return nil, errors.New("Unknown filesystem type requested")
 	}


### PR DESCRIPTION
This will allow for users to either create an iso from files in an
existing directory or just to specify a directory to be used as the
scratch space for staging files.

If nothing is provided we will fallback to the previous behavior
which would create a directory in the system temp directory

Fixes #100