### PR TITLE
use full set of valid characters for fat32 short name

### DIFF
--- a/filesystem/fat32/directoryentry.go
+++ b/filesystem/fat32/directoryentry.go
@@ -17,6 +17,62 @@ const (
 	charsPerSlot          int          = 13
 )
 
+// valid shortname characters - [A-F][0-9][$%'-_@~`!(){}^#&]
+var validShortNameCharacters = map[byte]bool{
+	0x21: true, // !
+	0x23: true, // #
+	0x24: true, // $
+	0x25: true, // %
+	0x26: true, // &
+	0x27: true, // '
+	0x28: true, // (
+	0x29: true, // )
+	0x2d: true, // -
+	0x30: true, // 0
+	0x31: true, // 1
+	0x32: true, // 2
+	0x33: true, // 3
+	0x34: true, // 4
+	0x35: true, // 5
+	0x36: true, // 6
+	0x37: true, // 7
+	0x38: true, // 8
+	0x39: true, // 9
+	0x40: true, // @
+	0x41: true, // A
+	0x42: true, // B
+	0x43: true, // C
+	0x44: true, // D
+	0x45: true, // E
+	0x46: true, // F
+	0x47: true, // G
+	0x48: true, // H
+	0x49: true, // I
+	0x4a: true, // J
+	0x4b: true, // K
+	0x4c: true, // L
+	0x4d: true, // M
+	0x4e: true, // N
+	0x4f: true, // O
+	0x50: true, // P
+	0x51: true, // Q
+	0x52: true, // R
+	0x53: true, // S
+	0x54: true, // T
+	0x55: true, // U
+	0x56: true, // V
+	0x57: true, // W
+	0x58: true, // X
+	0x59: true, // Y
+	0x5a: true, // Z
+	0x5e: true, // ^
+	0x5f: true, // _
+	0x60: true, // `
+	0x7b: true, // {
+	0x7d: true, // }
+	0x7e: true, // ~
+}
+
 // directoryEntry is a single directory entry
 type directoryEntry struct {
 	filenameShort      string
@@ -341,7 +397,7 @@ func stringToValidASCIIBytes(s string) ([]byte, error) {
 	// now make sure every byte is valid
 	for _, b2 := range b {
 		// only valid chars - 0-9, A-Z, _, ~
-		if (0x30 <= b2 && b2 <= 0x39) || (0x41 <= b2 && b2 <= 0x5a) || (b2 == 0x5f) || (b2 == 0x7e) {
+		if validShortNameCharacters[b2] {
 			continue
 		}
 		return nil, fmt.Errorf("Invalid 8.3 character")
@@ -429,8 +485,7 @@ func uCaseValid(name string) string {
 	r2 := make([]rune, 0, len(r))
 	for _, val := range r {
 		switch {
-		case (0x30 <= val && val <= 0x39) || (0x41 <= val && val <= 0x5a) || (val == 0x7e):
-			// naturally valid characters
+		case validShortNameCharacters[byte(val)]:
 			r2 = append(r2, val)
 		case (0x61 <= val && val <= 0x7a):
 			// lower-case characters should be upper-cased

--- a/filesystem/fat32/directoryentry_internal_test.go
+++ b/filesystem/fat32/directoryentry_internal_test.go
@@ -95,7 +95,7 @@ func getValidDirectoryEntries() ([]*directoryEntry, [][]byte, error) {
 	t4, _ := time.Parse(time.RFC3339, "2017-11-26T08:01:44Z")
 	t40, _ := time.Parse(time.RFC3339, "2017-11-26T00:00:00Z")
 	entries := []*directoryEntry{
-		&directoryEntry{
+		{
 			filenameShort:      "FOO",
 			fileExtension:      "",
 			filenameLong:       "",
@@ -117,7 +117,7 @@ func getValidDirectoryEntries() ([]*directoryEntry, [][]byte, error) {
 			longFilenameSlots: 0,
 			isNew:             false,
 		},
-		&directoryEntry{
+		{
 			filenameShort:   "TERCER~1",
 			fileExtension:   "",
 			filenameLong:    "tercer_archivo",
@@ -138,7 +138,7 @@ func getValidDirectoryEntries() ([]*directoryEntry, [][]byte, error) {
 			longFilenameSlots: 2,
 			isNew:             false,
 		},
-		&directoryEntry{
+		{
 			filenameShort:   "CORTO1",
 			fileExtension:   "TXT",
 			filenameLong:    "",
@@ -159,7 +159,7 @@ func getValidDirectoryEntries() ([]*directoryEntry, [][]byte, error) {
 			longFilenameSlots: 0,
 			isNew:             false,
 		},
-		&directoryEntry{
+		{
 			filenameShort:   "UNARCH~1",
 			fileExtension:   "DAT",
 			filenameLong:    "Un archivo con nombre largo.dat",
@@ -499,7 +499,7 @@ func TestDirectoryEntryUCaseValid(t *testing.T) {
 		{"aBC", "ABC"},
 		{"a15D", "A15D"},
 		{"A BC", "ABC"},
-		{"A..-a*)82y12112bb", "A_A__82Y12112BB"},
+		{"A..-a*)82y12112bb", "A-A_)82Y12112BB"},
 	}
 	for _, tt := range tests {
 		output := uCaseValid(tt.input)

--- a/filesystem/fat32/doc.go
+++ b/filesystem/fat32/doc.go
@@ -1,5 +1,9 @@
 // Package fat32 provides utilities to interact with, manipulate and create a FAT32 filesystem on a block device or
 // a disk image.
 //
+// references:
+//   https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system
+//   https://www.cs.fsu.edu/~cop4610t/assignments/project3/spec/fatspec.pdf
+//   https://wiki.osdev.org/FAT
 //
 package fat32


### PR DESCRIPTION
fixes #113 

Previosuly, we only had A-Z,0-9,~ as valid shortname characters. Rereading the spec, clearly there are about 10 more.