### PR TITLE
include Closer for all filesystem files; fix O_TRUNC in fat32

### DIFF
--- a/filesystem/fat32/file.go
+++ b/filesystem/fat32/file.go
@@ -3,6 +3,7 @@ package fat32
 import (
 	"fmt"
 	"io"
+	"os"
 )
 
 // File represents a single file in a FAT32 filesystem
@@ -22,6 +23,9 @@ type File struct {
 // and increments the offset by the number of bytes read.
 // Use Seek() to set at a particular point
 func (fl *File) Read(b []byte) (int, error) {
+	if fl == nil || fl.filesystem == nil {
+		return 0, os.ErrClosed
+	}
 	// we have the DirectoryEntry, so we can get the starting cluster location
 	// we then get a list of the clusters, and read the data from all of those clusters
 	// write the content for the file
@@ -97,6 +101,9 @@ func (fl *File) Read(b []byte) (int, error) {
 // and increments the offset by the number of bytes read.
 // Use Seek() to set at a particular point
 func (fl *File) Write(p []byte) (int, error) {
+	if fl == nil || fl.filesystem == nil {
+		return 0, os.ErrClosed
+	}
 	totalWritten := 0
 	fs := fl.filesystem
 	// if the file was not opened RDWR, nothing we can do
@@ -169,6 +176,9 @@ func (fl *File) Write(p []byte) (int, error) {
 
 // Seek set the offset to a particular point in the file
 func (fl *File) Seek(offset int64, whence int) (int64, error) {
+	if fl == nil || fl.filesystem == nil {
+		return 0, os.ErrClosed
+	}
 	newOffset := int64(0)
 	switch whence {
 	case io.SeekStart:
@@ -183,4 +193,10 @@ func (fl *File) Seek(offset int64, whence int) (int64, error) {
 	}
 	fl.offset = newOffset
 	return fl.offset, nil
+}
+
+// Close close the file
+func (fl *File) Close() error {
+	fl.filesystem = nil
+	return nil
 }

--- a/filesystem/fat32/table.go
+++ b/filesystem/fat32/table.go
@@ -9,6 +9,7 @@ import (
 type table struct {
 	fatID          uint32
 	eocMarker      uint32
+	unusedMarker   uint32
 	clusters       map[uint32]uint32
 	rootDirCluster uint32
 	size           uint32

--- a/filesystem/file.go
+++ b/filesystem/file.go
@@ -5,6 +5,7 @@ import "io"
 // File a reference to a single file on disk
 type File interface {
 	io.ReadWriteSeeker
+	io.Closer
 	//io.ReaderAt
 	//io.WriterAt
 }

--- a/filesystem/iso9660/file.go
+++ b/filesystem/iso9660/file.go
@@ -3,6 +3,7 @@ package iso9660
 import (
 	"fmt"
 	"io"
+	"os"
 )
 
 // File represents a single file in an iso9660 filesystem
@@ -12,6 +13,7 @@ type File struct {
 	isReadWrite bool
 	isAppend    bool
 	offset      int64
+	closed      bool
 }
 
 // Read reads up to len(b) bytes from the File.
@@ -20,6 +22,9 @@ type File struct {
 // reads from the last known offset in the file from last read or write
 // use Seek() to set at a particular point
 func (fl *File) Read(b []byte) (int, error) {
+	if fl == nil || fl.closed {
+		return 0, os.ErrClosed
+	}
 	// we have the DirectoryEntry, so we can get the starting location and size
 	// since iso9660 files are contiguous, we only need the starting location and size
 	//   to get the entire file
@@ -60,6 +65,9 @@ func (fl *File) Write(p []byte) (int, error) {
 
 // Seek set the offset to a particular point in the file
 func (fl *File) Seek(offset int64, whence int) (int64, error) {
+	if fl == nil || fl.closed {
+		return 0, os.ErrClosed
+	}
 	newOffset := int64(0)
 	switch whence {
 	case io.SeekStart:
@@ -78,4 +86,10 @@ func (fl *File) Seek(offset int64, whence int) (int64, error) {
 
 func (fl *File) Location() uint32 {
 	return fl.location
+}
+
+// Close close the file
+func (fl *File) Close() error {
+	fl.closed = true
+	return nil
 }

--- a/filesystem/squashfs/file.go
+++ b/filesystem/squashfs/file.go
@@ -3,6 +3,7 @@ package squashfs
 import (
 	"fmt"
 	"io"
+	"os"
 )
 
 // File represents a single file in a squashfs filesystem
@@ -23,6 +24,9 @@ type File struct {
 // reads from the last known offset in the file from last read or write
 // use Seek() to set at a particular point
 func (fl *File) Read(b []byte) (int, error) {
+	if fl == nil || fl.filesystem == nil {
+		return 0, os.ErrClosed
+	}
 	// squashfs files are *mostly* contiguous, we only need the starting location and size for whole blocks
 	// if there are fragments, we need the location of those as well
 
@@ -111,6 +115,9 @@ func (fl *File) Write(p []byte) (int, error) {
 
 // Seek set the offset to a particular point in the file
 func (fl *File) Seek(offset int64, whence int) (int64, error) {
+	if fl == nil || fl.filesystem == nil {
+		return 0, os.ErrClosed
+	}
 	newOffset := int64(0)
 	switch whence {
 	case io.SeekStart:
@@ -125,4 +132,10 @@ func (fl *File) Seek(offset int64, whence int) (int64, error) {
 	}
 	fl.offset = newOffset
 	return fl.offset, nil
+}
+
+// Close close the file
+func (fl *File) Close() error {
+	fl.filesystem = nil
+	return nil
 }

--- a/filesystem/squashfs/file_internal_test.go
+++ b/filesystem/squashfs/file_internal_test.go
@@ -5,5 +5,6 @@ func MakeTestFile(size uint64) *File {
 		extendedFile: &extendedFile{
 			fileSize: size,
 		},
+		filesystem: &FileSystem{},
 	}
 }


### PR DESCRIPTION
Also fixes #115 

It doesn't add O_TRUNC support to the other filesystems, but those can come later