### PR TITLE
disk: When GetPartitionTable succeeds, save result

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -48,9 +48,16 @@ var (
 
 // GetPartitionTable retrieves a PartitionTable for a Disk
 //
+// If the table is able to be retrieved from the disk, it is saved in the instance.
+//
 // returns an error if the Disk is invalid or does not exist, or the partition table is unknown
 func (d *Disk) GetPartitionTable() (partition.Table, error) {
-	return partition.Read(d.File, int(d.LogicalBlocksize), int(d.PhysicalBlocksize))
+	t, err := partition.Read(d.File, int(d.LogicalBlocksize), int(d.PhysicalBlocksize))
+	if err != nil {
+		return nil, err
+	}
+	d.Table = t
+	return t, nil
 }
 
 // Partition applies a partition.Table implementation to a Disk


### PR DESCRIPTION
Previously, it is only possible to read a partition after
writing the partition table.

Now, a call to GetPartitionTable will enable calls to GetPartition
and GetFilesystem to succeed without having to write a new partition
table.