### PR TITLE
update golint to revive, fix linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,8 @@ fmt-check:
 	fi
 
 ## Lint the files
-lint: golint golangci-lint
-	@$(BUILD_CMD) $(LINTER) run --disable-all --enable=golint ./...
-
-golint:
-ifeq (, $(shell which golint))
-	go get -u golang.org/x/lint/golint
-endif
+lint: golangci-lint
+	@$(BUILD_CMD) $(LINTER) run --disable-all --enable=revive ./...
 
 ## Vet the files
 vet:

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	BLKRRPART = 0x125f
+	blkrrpart = 0x125f
 )
 
 // ReReadPartitionTable forces the kernel to re-read the partition table
@@ -18,7 +18,7 @@ const (
 // It is done via an ioctl call with request as BLKRRPART.
 func (d *Disk) ReReadPartitionTable() error {
 	fd := d.File.Fd()
-	_, err := unix.IoctlGetInt(int(fd), BLKRRPART)
+	_, err := unix.IoctlGetInt(int(fd), blkrrpart)
 	if err != nil {
 		return fmt.Errorf("Unable to re-read partition table: %v", err)
 	}

--- a/filesystem/squashfs/compressor.go
+++ b/filesystem/squashfs/compressor.go
@@ -64,6 +64,7 @@ func (c CompressorLzma) flavour() compression {
 
 type GzipStrategy uint16
 
+// gzip strategy options
 const (
 	GzipDefault          GzipStrategy = 0x1
 	GzipFiltered                      = 0x2
@@ -146,6 +147,7 @@ func (c CompressorGzip) flavour() compression {
 // XzFilter filter for xz compression
 type XzFilter uint32
 
+// xz filter options
 const (
 	XzFilterX86      XzFilter = 0x1
 	XzFilterPowerPC           = 0x2

--- a/util/version.go
+++ b/util/version.go
@@ -1,5 +1,6 @@
 package util
 
 const (
+	// AppNameVersion name and URL to app
 	AppNameVersion = "https://github.com/diskfs/go-diskfs"
 )


### PR DESCRIPTION
Remove final dependency on deprecated golint, replace with revive. Update to pass linting.