### PR TITLE
Add Darwin disk blocks support (/dev/diskX / /dev/rdiskX)

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -118,8 +118,8 @@ import (
 //    so we use the default sector size of 512, per Rod Smith
 const (
 	defaultBlocksize, firstblock int = 512, 2048
-	blksszGet                        = 0x1268
-	blkpbszGet                       = 0x127b
+	// blksszGet                        = 0x1268
+	// blkpbszGet                       = 0x127b
 )
 
 // Format represents the format of the disk

--- a/diskfs_darwin.go
+++ b/diskfs_darwin.go
@@ -1,5 +1,3 @@
-// +build !darwin linux solaris aix freebsd illumos netbsd openbsd plan9
-
 package diskfs
 
 import (
@@ -9,18 +7,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// this constants should be part of "golang.org/x/sys/unix", but aren't, yet
+const (
+	DKIOCGETBLOCKSIZE         = 0x40046418
+	DKIOCGETPHYSICALBLOCKSIZE = 0x4004644D
+	DKIOCGETBLOCKCOUNT        = 0x40086419
+)
+
 // getSectorSizes get the logical and physical sector sizes for a block device
 func getSectorSizes(f *os.File) (int64, int64, error) {
 	/*
 		ioctl(fd, BLKPBSZGET, &physicalsectsize);
+
 	*/
 	fd := f.Fd()
 
-	logicalSectorSize, err := unix.IoctlGetInt(int(fd), unix.BLKSSZGET)
+	logicalSectorSize, err := unix.IoctlGetInt(int(fd), DKIOCGETBLOCKSIZE)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Unable to get device logical sector size: %v", err)
 	}
-	physicalSectorSize, err := unix.IoctlGetInt(int(fd), unix.BLKPBSZGET)
+	physicalSectorSize, err := unix.IoctlGetInt(int(fd), DKIOCGETPHYSICALBLOCKSIZE)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Unable to get device physical sector size: %v", err)
 	}

--- a/diskfs_unix.go
+++ b/diskfs_unix.go
@@ -15,7 +15,7 @@ func getSectorSizes(f *os.File) (int64, int64, error) {
 		ioctl(fd, BLKPBSZGET, &physicalsectsize);
 	*/
 	fd := f.Fd()
-
+- 
 	logicalSectorSize, err := unix.IoctlGetInt(int(fd), unix.BLKSSZGET)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Unable to get device logical sector size: %v", err)

--- a/diskfs_unix.go
+++ b/diskfs_unix.go
@@ -1,3 +1,4 @@
+//go:build !darwin || linux || solaris || aix || freebsd || illumos || netbsd || openbsd || plan9
 // +build !darwin linux solaris aix freebsd illumos netbsd openbsd plan9
 
 package diskfs
@@ -15,7 +16,7 @@ func getSectorSizes(f *os.File) (int64, int64, error) {
 		ioctl(fd, BLKPBSZGET, &physicalsectsize);
 	*/
 	fd := f.Fd()
-- 
+
 	logicalSectorSize, err := unix.IoctlGetInt(int(fd), unix.BLKSSZGET)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Unable to get device logical sector size: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/pkg/xattr v0.4.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/ulikunitz/xz v0.5.10
-	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	gopkg.in/djherbis/times.v1 v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/djherbis/times.v1 v1.2.0 h1:UCvDKl1L/fmBygl2Y7hubXCnY7t4Yj46ZrBFNUipFbM=


### PR DESCRIPTION
- Adds support for disk blocks on darwin (`/dev/(r)?disk.+`)
- Updated the /sys/unix dependency and based the `ioctl` syscalls from its constants instead in linux

Notes:
- It still works with regular files on darwin, happens that the previous ioctl syscall flags are specific for some unix systems (linux included), but not for freebsd and darwin. 