### PR TITLE
Check the filepath.WalkFunc error in iso9660.Finalize

### DIFF
--- a/filesystem/iso9660/finalize.go
+++ b/filesystem/iso9660/finalize.go
@@ -824,7 +824,10 @@ func walkTree(workspace string) ([]*finalizeFileInfo, map[string]*finalizeFileIn
 	dirList := make(map[string]*finalizeFileInfo)
 	fileList := make([]*finalizeFileInfo, 0)
 	var entry *finalizeFileInfo
-	filepath.Walk(".", func(fp string, fi os.FileInfo, err error) error {
+	err = filepath.Walk(".", func(fp string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("Error walking path %s: %v", fp, err)
+		}
 		isRoot := fp == "."
 		name := fi.Name()
 		shortname, extension := calculateShortnameExtension(name)
@@ -856,6 +859,9 @@ func walkTree(workspace string) ([]*finalizeFileInfo, map[string]*finalizeFileIn
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 	// reset the workspace
 	os.Chdir(cwd)
 	return fileList, dirList, nil


### PR DESCRIPTION
If there is an error getting the file information at any point in the
tree info will be nil and err will be set. The WalkFunc must decide how
to handle the passed error.

In this case, as we can't finalize the iso, we choose to error out.

Before this fix, a failure to access some file in the tree would cause a
panic.