### PR TITLE
Use sys/unix constants for ioctls

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -118,8 +118,6 @@ import (
 //    so we use the default sector size of 512, per Rod Smith
 const (
 	defaultBlocksize, firstblock int = 512, 2048
-	blksszGet                        = 0x1268
-	blkpbszGet                       = 0x127b
 )
 
 // Format represents the format of the disk

--- a/diskfs_unix.go
+++ b/diskfs_unix.go
@@ -16,11 +16,11 @@ func getSectorSizes(f *os.File) (int64, int64, error) {
 
 	*/
 	fd := f.Fd()
-	logicalSectorSize, err := unix.IoctlGetInt(int(fd), blksszGet)
+	logicalSectorSize, err := unix.IoctlGetInt(int(fd), unix.BLKSSZGET)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Unable to get device logical sector size: %v", err)
 	}
-	physicalSectorSize, err := unix.IoctlGetInt(int(fd), blkpbszGet)
+	physicalSectorSize, err := unix.IoctlGetInt(int(fd), unix.BLKPBSZGET)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Unable to get device physical sector size: %v", err)
 	}


### PR DESCRIPTION
This fixes functionality on multiple CPU architectures.

The previously hardcoded blksszGet and blkpbszGet values are the correct
ioctl values on only a few architectures. PowerPC, MIPS, and Sparc use
different bit layouts in their ioctls, so it's best to get these values
from the sys/unix library.