### PR TITLE
Add the ability to adjust the sector size while creating Disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ diskSize int := espSize + 4*1024*1024 // 104 MB
 
 // create a disk image
 diskImg := "/tmp/disk.img"
-disk := diskfs.Create(diskImg, diskSize, diskfs.Raw)
+disk := diskfs.Create(diskImg, diskSize, diskfs.Raw, diskfs.SectorSizeDefault)
 // create a partition table
 blkSize int := 512
 partitionSectors int := espSize / blkSize

--- a/diskfs.go
+++ b/diskfs.go
@@ -184,8 +184,8 @@ func initDisk(f *os.File, openMode OpenModeOption, sectorSize SectorSize) (*disk
 	var (
 		diskType      disk.Type
 		size          int64
-		lblksize      int64
-		pblksize      int64
+		lblksize      = int64(defaultBlocksize)
+		pblksize      = int64(defaultBlocksize)
 		defaultBlocks = true
 	)
 	log.Debug("initDisk(): start")
@@ -193,9 +193,6 @@ func initDisk(f *os.File, openMode OpenModeOption, sectorSize SectorSize) (*disk
 	if sectorSize != SectorSizeDefault {
 		lblksize = int64(sectorSize)
 		pblksize = int64(sectorSize)
-	} else {
-		lblksize = int64(defaultBlocksize)
-		pblksize = int64(defaultBlocksize)
 	}
 
 	// get device information

--- a/diskfs_test.go
+++ b/diskfs_test.go
@@ -98,22 +98,25 @@ func TestOpen(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	tests := []struct {
-		path   string
-		size   int64
-		format diskfs.Format
-		disk   *disk.Disk
-		err    error
+		path       string
+		size       int64
+		format     diskfs.Format
+		sectorSize diskfs.SectorSize
+		disk       *disk.Disk
+		err        error
 	}{
-		{"", 10 * oneMB, diskfs.Raw, nil, fmt.Errorf("must pass device name")},
-		{"/tmp/disk.img", 0, diskfs.Raw, nil, fmt.Errorf("must pass valid device size to create")},
-		{"/tmp/disk.img", -1, diskfs.Raw, nil, fmt.Errorf("must pass valid device size to create")},
-		{"/tmp/foo/bar/232323/23/2322/disk.img", 10 * oneMB, diskfs.Raw, nil, fmt.Errorf("Could not create device")},
-		{"/tmp/disk.img", 10 * oneMB, diskfs.Raw, &disk.Disk{LogicalBlocksize: 512, PhysicalBlocksize: 512, Size: 10 * oneMB, Type: disk.File}, nil},
+		{"", 10 * oneMB, diskfs.Raw, diskfs.SectorSizeDefault, nil, fmt.Errorf("must pass device name")},
+		{"/tmp/disk.img", 0, diskfs.Raw, diskfs.SectorSizeDefault, nil, fmt.Errorf("must pass valid device size to create")},
+		{"/tmp/disk.img", -1, diskfs.Raw, diskfs.SectorSizeDefault, nil, fmt.Errorf("must pass valid device size to create")},
+		{"/tmp/foo/bar/232323/23/2322/disk.img", 10 * oneMB, diskfs.Raw, diskfs.SectorSizeDefault, nil, fmt.Errorf("Could not create device")},
+		{"/tmp/disk.img", 10 * oneMB, diskfs.Raw, diskfs.SectorSizeDefault, &disk.Disk{LogicalBlocksize: 512, PhysicalBlocksize: 512, Size: 10 * oneMB, Type: disk.File}, nil},
+		{"/tmp/disk.img", 10 * oneMB, diskfs.Raw, diskfs.SectorSize512, &disk.Disk{LogicalBlocksize: 512, PhysicalBlocksize: 512, Size: 10 * oneMB, Type: disk.File}, nil},
+		{"/tmp/disk.img", 10 * oneMB, diskfs.Raw, diskfs.SectorSize4k, &disk.Disk{LogicalBlocksize: 4096, PhysicalBlocksize: 4096, Size: 10 * oneMB, Type: disk.File}, nil},
 	}
 
 	for i, tt := range tests {
-		disk, err := diskfs.Create(tt.path, tt.size, tt.format)
-		msg := fmt.Sprintf("%d: Create(%s, %d, %v)", i, tt.path, tt.size, tt.format)
+		disk, err := diskfs.Create(tt.path, tt.size, tt.format, tt.sectorSize)
+		msg := fmt.Sprintf("%d: Create(%s, %d, %v, %d)", i, tt.path, tt.size, tt.format, tt.sectorSize)
 		switch {
 		case (err == nil && tt.err != nil) || (err != nil && tt.err == nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
 			t.Errorf("%s: mismatched errors, actual %v expected %v", msg, err, tt.err)

--- a/examples/bootable_iso.go
+++ b/examples/bootable_iso.go
@@ -16,7 +16,7 @@ func CreateBootableIso(diskImg string) {
 		log.Fatal("must have a valid path for diskImg")
 	}
 	var diskSize int64 = 10 * 1024 * 1024 // 10 MB
-	mydisk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw)
+	mydisk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw, diskfs.SectorSizeDefault)
 	check(err)
 
 	// the following line is required for an ISO, which may have logical block sizes

--- a/examples/efi_create.go
+++ b/examples/efi_create.go
@@ -26,7 +26,7 @@ func CreateEfi(diskImg string) {
 	)
 
 	// create a disk image
-	disk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw)
+	disk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw, diskfs.SectorSizeDefault)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/examples/iso_create.go
+++ b/examples/iso_create.go
@@ -16,7 +16,7 @@ func CreateIso(diskImg string) {
 		log.Fatal("must have a valid path for diskImg")
 	}
 	var diskSize int64 = 10 * 1024 * 1024 // 10 MB
-	mydisk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw)
+	mydisk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw, diskfs.SectorSizeDefault)
 	check(err)
 
 	// the following line is required for an ISO, which may have logical block sizes

--- a/examples/squashfs_create.go
+++ b/examples/squashfs_create.go
@@ -16,7 +16,7 @@ func CreateSquashfs(diskImg string) {
 		log.Fatal("must have a valid path for diskImg")
 	}
 	var diskSize int64 = 10 * 1024 * 1024 // 10 MB
-	mydisk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw)
+	mydisk, err := diskfs.Create(diskImg, diskSize, diskfs.Raw, diskfs.SectorSizeDefault)
 	check(err)
 
 	fspec := disk.FilesystemSpec{Partition: 0, FSType: filesystem.TypeSquashfs, VolumeLabel: "label"}

--- a/filesystem/fat32/testdata/fat32.go
+++ b/filesystem/fat32/testdata/fat32.go
@@ -20,7 +20,7 @@ func main() {
 }
 func mkfs(name string) filesystem.FileSystem {
 	size := int64(10 * 1024 * 1024)
-	d, err := diskfs.Create(name, size, diskfs.Raw)
+	d, err := diskfs.Create(name, size, diskfs.Raw, diskfs.SectorSizeDefault)
 	if err != nil {
 		fmt.Printf("Error creating disk: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
This fixes #133 .

As discussed on the issue above, per recommendation I added an additional parameter to the `diskfs.Create()` function that allows customization of sector size - currently only in the case of regular files.

Questions here:
1. Should we also override the sector size for block devices in this case? I wasn't sure so I left it to auto-detect always.
2. Naming. It's hard for me to find good names for the values!

Please be gentle, Go is still not very native for me.