### PR TITLE
Support passing sector size to Open*() calls as well.

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -117,9 +117,9 @@ import (
 // when we use a disk image with a GPT, we cannot get the logical sector size from the disk via the kernel
 //    so we use the default sector size of 512, per Rod Smith
 const (
-	defaultBlocksize, firstblock int = 512, 2048
-	blksszGet                        = 0x1268
-	blkpbszGet                       = 0x127b
+	defaultBlocksize = 512
+	blksszGet        = 0x1268
+	blkpbszGet       = 0x127b
 )
 
 // Format represents the format of the disk
@@ -271,7 +271,7 @@ func checkDevice(device string) error {
 // Open a Disk from a path to a device in read-write exclusive mode
 // Should pass a path to a block device e.g. /dev/sda or a path to a file /tmp/foo.img
 // The provided device must exist at the time you call Open()
-func Open(device string) (*disk.Disk, error) {
+func Open(device string, sectorSize SectorSize) (*disk.Disk, error) {
 	err := checkDevice(device)
 	if err != nil {
 		return nil, err
@@ -281,7 +281,7 @@ func Open(device string) (*disk.Disk, error) {
 		return nil, fmt.Errorf("Could not open device %s exclusively for writing", device)
 	}
 	// return our disk
-	return initDisk(f, ReadWriteExclusive, SectorSizeDefault)
+	return initDisk(f, ReadWriteExclusive, sectorSize)
 }
 
 // OpenWithMode open a Disk from a path to a device with a given open mode
@@ -289,7 +289,7 @@ func Open(device string) (*disk.Disk, error) {
 // return an error
 // Should pass a path to a block device e.g. /dev/sda or a path to a file /tmp/foo.img
 // The provided device must exist at the time you call OpenWithMode()
-func OpenWithMode(device string, mode OpenModeOption) (*disk.Disk, error) {
+func OpenWithMode(device string, sectorSize SectorSize, mode OpenModeOption) (*disk.Disk, error) {
 	err := checkDevice(device)
 	if err != nil {
 		return nil, err
@@ -303,7 +303,7 @@ func OpenWithMode(device string, mode OpenModeOption) (*disk.Disk, error) {
 		return nil, fmt.Errorf("Could not open device %s with mode %v: %v", device, mode, err)
 	}
 	// return our disk
-	return initDisk(f, mode, SectorSizeDefault)
+	return initDisk(f, mode, sectorSize)
 }
 
 // Create a Disk from a path to a device

--- a/diskfs_test.go
+++ b/diskfs_test.go
@@ -56,17 +56,19 @@ func TestOpen(t *testing.T) {
 	size := fileInfo.Size()
 
 	tests := []struct {
-		path string
-		disk *disk.Disk
-		err  error
+		path       string
+		disk       *disk.Disk
+		sectorSize diskfs.SectorSize
+		err        error
 	}{
-		{"", nil, fmt.Errorf("must pass device name")},
-		{"/tmp/foo/bar/232323/23/2322/disk.img", nil, fmt.Errorf("")},
-		{path, &disk.Disk{Type: disk.File, LogicalBlocksize: 512, PhysicalBlocksize: 512, Size: size}, nil},
+		{"", nil, diskfs.SectorSizeDefault, fmt.Errorf("must pass device name")},
+		{"/tmp/foo/bar/232323/23/2322/disk.img", nil, diskfs.SectorSizeDefault, fmt.Errorf("")},
+		{path, &disk.Disk{Type: disk.File, LogicalBlocksize: 512, PhysicalBlocksize: 512, Size: size}, diskfs.SectorSizeDefault, nil},
+		{path, &disk.Disk{Type: disk.File, LogicalBlocksize: 4096, PhysicalBlocksize: 4096, Size: size}, diskfs.SectorSize4k, nil},
 	}
 
 	for _, tt := range tests {
-		d, err := diskfs.Open(tt.path)
+		d, err := diskfs.Open(tt.path, tt.sectorSize)
 		msg := fmt.Sprintf("Open(%s)", tt.path)
 		switch {
 		case (err == nil && tt.err != nil) || (err != nil && tt.err == nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
@@ -81,7 +83,7 @@ func TestOpen(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		d, err := diskfs.OpenWithMode(tt.path, diskfs.ReadOnly)
+		d, err := diskfs.OpenWithMode(tt.path, tt.sectorSize, diskfs.ReadOnly)
 		msg := fmt.Sprintf("%d: Open(%s)", i, tt.path)
 		switch {
 		case (err == nil && tt.err != nil) || (err != nil && tt.err == nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):

--- a/examples/filesystem_read.go
+++ b/examples/filesystem_read.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ReadFilesystem(p string) {
-	disk, err := diskfs.Open(p)
+	disk, err := diskfs.Open(p, diskfs.SectorSizeDefault)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/examples/iso_info.go
+++ b/examples/iso_info.go
@@ -12,7 +12,7 @@ import (
 )
 
 func PrintIsoInfo(isoPath string) {
-	disk, err := diskfs.Open(isoPath)
+	disk, err := diskfs.Open(isoPath, diskfs.SectorSizeDefault)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Forgot that we also need to support setting sector size for `Open*()` calls, since when we open file images there is no way of determining the sector size that got used - and this might make a difference.

This is a follow up to #135 . Sorry for not bundling that in, I was too focused on my `Create()` use-case!