### PR TITLE
Adding hyphen to the regex because it is a valid character in file names

### DIFF
--- a/filesystem/iso9660/finalize.go
+++ b/filesystem/iso9660/finalize.go
@@ -888,7 +888,7 @@ func calculateShortnameExtension(name string) (string, string) {
 	extension = strings.ToUpper(extension)
 
 	// replace illegal characters in shortname and extension with _
-	re := regexp.MustCompile("[^A-Z0-9_]")
+	re := regexp.MustCompile("[^A-Z0-9_-]")
 	shortname = re.ReplaceAllString(shortname, "_")
 	extension = re.ReplaceAllString(extension, "_")
 

--- a/filesystem/iso9660/finalize_internal_test.go
+++ b/filesystem/iso9660/finalize_internal_test.go
@@ -200,3 +200,30 @@ func TestCollapseAndSortChildren(t *testing.T) {
 		t.Log(output)
 	}
 }
+
+func TestCalculateShortnameExtension(t *testing.T) {
+	var tests = []struct {
+		name              string
+		filename          string
+		expectedShortName string
+		expectedExtension string
+	}{
+		{"hyphen test, no extension", "meta-data", "META-DATA", ""},
+		{"hyphen test with period", "meta-data.", "META-DATA", ""},
+		{"hyphen test with extension", "meta-data.json", "META-DATA", "JSON"},
+		{"underscore test, no extension", "meta_data", "META_DATA", ""},
+		{"underscore test with extension", "meta_data.json", "META_DATA", "JSON"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shortName, ext := calculateShortnameExtension(tt.filename)
+			if shortName != tt.expectedShortName {
+				t.Errorf("expected: %s, got: %s", tt.expectedShortName, shortName)
+			}
+			if ext != tt.expectedExtension {
+				t.Errorf("expected: %s, got: %s", tt.expectedExtension, ext)
+			}
+		})
+	}
+}


### PR DESCRIPTION

This adds the hyphen to the regex and adds unit tests.

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>