### PR TITLE
allow gpt partitions of 1 block

### DIFF
--- a/partition/gpt/partition_internal_test.go
+++ b/partition/gpt/partition_internal_test.go
@@ -367,7 +367,7 @@ func TestWriteContents(t *testing.T) {
 		partition := Partition{
 			Start:      2048,
 			End:        2048,
-			Size:       uint64(1),
+			Size:       uint64(512),
 			Name:       "EFI System",
 			GUID:       "5CA3360B-5DE6-4FCF-B4CE-419CEE433B51",
 			Attributes: 0,
@@ -384,8 +384,8 @@ func TestWriteContents(t *testing.T) {
 			},
 		}
 		read, err := partition.WriteContents(f, reader)
-		if read != 0 {
-			t.Errorf("Returned %d bytes read instead of 0", read)
+		if read != partition.Size {
+			t.Errorf("Returned %d bytes read instead of %d", read, partition.Size)
 		}
 		if err == nil {
 			t.Errorf("Returned nil error instead of actual errors")

--- a/partition/gpt/partiton.go
+++ b/partition/gpt/partiton.go
@@ -147,12 +147,14 @@ func (p *Partition) WriteContents(f util.File, contents io.Reader) (uint64, erro
 	// validate start/end/size
 	calculatedSize := (p.End - p.Start + 1) * uint64(lss)
 	switch {
-	case p.Size <= 0 && p.End > p.Start:
-		p.Size = calculatedSize
-	case p.Size > 0 && p.End <= p.Start:
-		p.End = p.Start + p.Size/uint64(lss)
 	case p.Size > 0 && p.Size == calculatedSize:
 		// all is good
+	case p.Size == 0 && p.End >= p.Start:
+		// Size was not set
+		p.Size = calculatedSize
+	case p.Size > 0 && p.End == 0:
+		// End was not set
+		p.End = p.Start + p.Size/uint64(lss) - 1
 	default:
 		return total, fmt.Errorf("Cannot reconcile partition size %d with start %d / end %d", p.Size, p.Start, p.End)
 	}
@@ -250,11 +252,12 @@ func (p *Partition) initEntry(blocksize uint64, starting uint64) error {
 	size, start, end := part.Size, part.Start, part.End
 	calculatedSize := (end - start + 1) * blocksize
 	switch {
-	case start >= 0 && end > start && size == calculatedSize:
-	case size == 0 && start >= 0 && end > start:
+	case start >= 0 && end >= start && size == calculatedSize:
+	case size == 0 && start >= 0 && end >= start:
 		// provided specific start and end, so calculate size
 		part.Size = uint64(calculatedSize)
 	case size > 0 && start > 0 && end == 0:
+		// provided specific start and size, so calculate end
 		part.End = start + size/uint64(blocksize) - 1
 	case size > 0 && start == 0 && end == 0:
 		// we start right after the end of the previous

--- a/partition/gpt/partiton.go
+++ b/partition/gpt/partiton.go
@@ -152,7 +152,7 @@ func (p *Partition) WriteContents(f util.File, contents io.Reader) (uint64, erro
 	case p.Size == 0 && p.End >= p.Start:
 		// Size was not set
 		p.Size = calculatedSize
-	case p.Size > 0 && p.End == 0:
+	case p.Size > 0 && p.Size%uint64(lss) == 0 && p.End == 0:
 		// End was not set
 		p.End = p.Start + p.Size/uint64(lss) - 1
 	default:
@@ -256,10 +256,10 @@ func (p *Partition) initEntry(blocksize uint64, starting uint64) error {
 	case size == 0 && start >= 0 && end >= start:
 		// provided specific start and end, so calculate size
 		part.Size = uint64(calculatedSize)
-	case size > 0 && start > 0 && end == 0:
+	case size > 0 && size%uint64(blocksize) == 0 && start > 0 && end == 0:
 		// provided specific start and size, so calculate end
 		part.End = start + size/uint64(blocksize) - 1
-	case size > 0 && start == 0 && end == 0:
+	case size > 0 && size%uint64(blocksize) == 0 && start == 0 && end == 0:
 		// we start right after the end of the previous
 		start = uint64(starting)
 		end = start + size/uint64(blocksize) - 1


### PR DESCRIPTION
This fixes 2 off by one issues in creating GPT partitions.

As EndingLBA is the last included LBA of a partition Start and End can point to the same LBA.
The logic "part.End = start + size/uint64(blocksize) - 1" in initEntry also applies to WriteContents.

I also added checks to ensure partition sizes are a multiple of the logicalSectorSize.  Other sizes are not possible by the design of GPT partition entries. The alignment should be the responsibility of the caller but as most probably use sizes in full MiB violations seem rare.