### PR TITLE
iso9660/finalize: parse empty path correctly

### DIFF
--- a/filesystem/iso9660/finalize.go
+++ b/filesystem/iso9660/finalize.go
@@ -296,7 +296,7 @@ func (fi *finalizeFileInfo) findEntry(p string) (*finalizeFileInfo, error) {
 		err    error
 	)
 	parts := splitPath(p)
-	if len(parts) == 0 {
+	if len(parts) == 0 || p == "." {
 		target = fi
 	} else {
 		current := parts[0]


### PR DESCRIPTION
findEntry does not understand what to do when path.Dir returns "." on a file with no directory. This happens when we don't pass a BootCatalog, the default ones do not contain a path, or when we include a BootFile without any path.

Signed-off-by: Morten Linderud <morten.linderud@mullvad.net>