### PR TITLE
partition/gpt: check partitions array size before indexing

### DIFF
--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -373,6 +373,10 @@ func tableFromBytes(b []byte, logicalBlockSize, physicalBlockSize int) (*Table, 
 	// now for partitions
 	partArrayStart := partitionEntryFirstLBA * uint64(logicalBlockSize)
 	partArrayEnd := partArrayStart + uint64(partitionEntryCount*partitionEntrySize)
+	if partArrayEnd > uint64(cap(b)) {
+		return nil, fmt.Errorf("parition array end index (%d) exceeds gpt area size (%d)", partArrayEnd, cap(b))
+	}
+
 	bpart := b[partArrayStart:partArrayEnd]
 	// we need a CRC/zlib of the partition entries, so we do those first, then append the bytes
 	checksum = crc32.ChecksumIEEE(bpart)


### PR DESCRIPTION
In some cases this slice is ends up out of bounds so check capacity before indexing to prevent a panic.

Specifically this happens with the Fedora 37 Server iso here: https://download.fedoraproject.org/pub/fedora/linux/releases/37/Server/x86_64/iso/Fedora-Server-dvd-x86_64-37-1.7.iso

Just trying to `diskfs.Open("Fedora-Server-dvd-x86_64-37-1.7.iso")` causes the following panic:
```
panic: runtime error: slice bounds out of range [:32768] with capacity 17408

goroutine 1 [running]:
github.com/diskfs/go-diskfs/partition/gpt.tableFromBytes({0xc00013a000, 0xc00013a000?, 0x4400}, 0x200, 0x4864af?)
	/home/ncarboni/Source/go-diskfs/partition/gpt/table.go:376 +0xc57
github.com/diskfs/go-diskfs/partition/gpt.Read({0x589128, 0xc000014038}, 0x200, 0x50?)
	/home/ncarboni/Source/go-diskfs/partition/gpt/table.go:514 +0x165
github.com/diskfs/go-diskfs/partition.Read({0x589128, 0xc000014038}, 0x549880?, 0xc000110901?)
	/home/ncarboni/Source/go-diskfs/partition/partition.go:16 +0x31
github.com/diskfs/go-diskfs/disk.(*Disk).GetPartitionTable(0xc00007e0f0)
	/home/ncarboni/Source/go-diskfs/disk/disk.go:55 +0x30
github.com/diskfs/go-diskfs.initDisk(0xc000014038, 0x12?, 0x0)
	/home/ncarboni/Source/go-diskfs/diskfs.go:255 +0x6dc
github.com/diskfs/go-diskfs.Open({0x556d72, 0x12}, {0x0, 0x0, 0x404cdc?})
	/home/ncarboni/Source/go-diskfs/diskfs.go:332 +0x154
main.main()
	/home/ncarboni/Documents/scratch/golang/diskfs-isoinfo/main.go:14 +0x30
exit status 2
```

This patch resolves the issue, but I'm unsure how to test it.
Any ideas @deitch ?