### PR TITLE
Close file on InitDisk if its a block device

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -217,6 +217,7 @@ func initDisk(f *os.File, openMode OpenModeOption, sectorSize SectorSize) (*disk
 		if err != nil {
 			return nil, fmt.Errorf("error opening block device %s: %s", f.Name(), err)
 		}
+		defer file.Close()
 		size, err = file.Seek(0, io.SeekEnd)
 		if err != nil {
 			return nil, fmt.Errorf("error seeking to end of block device %s: %s", f.Name(), err)


### PR DESCRIPTION
Looks like if its a block device, on initDisk we re-open the block device to get the size, but unfortunately we never close it. As the life of that os.File is very short, we should release it as soon as possible in case other process may be trying to access the same block device

Signed-off-by: Itxaka <itxaka@spectrocloud.com>