### PR TITLE
Detect block device size using platform-specific IOCTL on Mac & Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,35 @@ jobs:
     name: Build
     strategy:
       matrix:
+        target: [
+          # Tier 1
+          {arch: amd64, os: linux},   {arch: arm64, os: linux},
+          {arch: amd64, os: windows}, {arch: arm64, os: windows},
+          {arch: amd64, os: darwin},  {arch: arm64, os: darwin},
+
+          # Tier 2 (Best effort)
+          {arch: amd64, os: freebsd}, {arch: arm64, os: freebsd},
+          {arch: amd64, os: netbsd},  {arch: arm64, os: netbsd},
+          {arch: amd64, os: openbsd}, {arch: arm64, os: openbsd},
+          {arch: amd64, os: solaris},
+          {arch: amd64, os: illumos},
+          {arch: ppc64, os: aix},
+        ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+      - run: go build
+        env:
+          GOOS: ${{ matrix.target.os }}
+          GOARCH: ${{ matrix.target.arch }}
+  test:
+    name: Test
+    strategy:
+      matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/diskfs.go
+++ b/diskfs.go
@@ -105,7 +105,6 @@ package diskfs
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -213,14 +212,9 @@ func initDisk(f *os.File, openMode OpenModeOption, sectorSize SectorSize) (*disk
 	case mode&os.ModeDevice != 0:
 		log.Debug("initDisk(): block device")
 		diskType = disk.Device
-		file, err := os.Open(f.Name())
+		size, err = getBlockDeviceSize(f)
 		if err != nil {
-			return nil, fmt.Errorf("error opening block device %s: %s", f.Name(), err)
-		}
-		defer file.Close()
-		size, err = file.Seek(0, io.SeekEnd)
-		if err != nil {
-			return nil, fmt.Errorf("error seeking to end of block device %s: %s", f.Name(), err)
+			return nil, fmt.Errorf("error getting block device %s size: %s", f.Name(), err)
 		}
 		lblksize, pblksize, err = getSectorSizes(f)
 		log.Debugf("initDisk(): logical block size %d, physical block size %d", lblksize, pblksize)

--- a/diskfs_darwin.go
+++ b/diskfs_darwin.go
@@ -14,6 +14,22 @@ const (
 	DKIOCGETBLOCKCOUNT        = 0x40086419
 )
 
+// getBlockDeviceSize get the size of an opened block device in Bytes.
+func getBlockDeviceSize(f *os.File) (int64, error) {
+	fd := f.Fd()
+
+	blockSize, err := unix.IoctlGetInt(int(fd), DKIOCGETBLOCKSIZE)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get device logical sector size: %v", err)
+	}
+
+	blockCount, err := unix.IoctlGetInt(int(fd), DKIOCGETBLOCKCOUNT)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get device block count: %v", err)
+	}
+	return int64(blockSize) * int64(blockCount), nil
+}
+
 // getSectorSizes get the logical and physical sector sizes for a block device
 func getSectorSizes(f *os.File) (logicalSectorSize, physicalSectorSize int64, err error) {
 	fd := f.Fd()

--- a/diskfs_darwin.go
+++ b/diskfs_darwin.go
@@ -16,11 +16,6 @@ const (
 
 // getSectorSizes get the logical and physical sector sizes for a block device
 func getSectorSizes(f *os.File) (logicalSectorSize, physicalSectorSize int64, err error) {
-	//nolint:gocritic // we keep this for reference to the underlying syscall
-	/*
-		ioctl(fd, BLKPBSZGET, &physicalsectsize);
-
-	*/
 	fd := f.Fd()
 
 	logicalSectorSizeInt, err := unix.IoctlGetInt(int(fd), DKIOCGETBLOCKSIZE)

--- a/diskfs_linux.go
+++ b/diskfs_linux.go
@@ -1,6 +1,3 @@
-//go:build linux || solaris || aix || freebsd || illumos || netbsd || openbsd || plan9
-// +build linux solaris aix freebsd illumos netbsd openbsd plan9
-
 package diskfs
 
 import (

--- a/diskfs_linux.go
+++ b/diskfs_linux.go
@@ -7,6 +7,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// getBlockDeviceSize get the size of an opened block device in Bytes.
+func getBlockDeviceSize(f *os.File) (int64, error) {
+	blockDeviceSize, err := unix.IoctlGetInt(int(f.Fd()), unix.BLKGETSIZE64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get block device size: %v", err)
+	}
+	return int64(blockDeviceSize), nil
+}
+
 // getSectorSizes get the logical and physical sector sizes for a block device
 func getSectorSizes(f *os.File) (logicalSectorSize, physicalSectorSize int64, err error) {
 	//

--- a/diskfs_other.go
+++ b/diskfs_other.go
@@ -1,0 +1,13 @@
+//go:build !windows && !linux && !darwin
+
+package diskfs
+
+import (
+	"errors"
+	"os"
+)
+
+// getSectorSizes get the logical and physical sector sizes for a block device
+func getSectorSizes(f *os.File) (logicalSectorSize, physicalSectorSize int64, err error) {
+	return 0, 0, errors.New("block devices not supported on this platform")
+}

--- a/diskfs_other.go
+++ b/diskfs_other.go
@@ -7,6 +7,11 @@ import (
 	"os"
 )
 
+// getBlockDeviceSize get the size of an opened block device in Bytes.
+func getBlockDeviceSize(f *os.File) (int64, error) {
+	return 0, errors.New("block devices not supported on this platform")
+}
+
 // getSectorSizes get the logical and physical sector sizes for a block device
 func getSectorSizes(f *os.File) (logicalSectorSize, physicalSectorSize int64, err error) {
 	return 0, 0, errors.New("block devices not supported on this platform")

--- a/diskfs_windows.go
+++ b/diskfs_windows.go
@@ -5,6 +5,11 @@ import (
 	"os"
 )
 
+// getBlockDeviceSize get the size of an opened block device in Bytes.
+func getBlockDeviceSize(f *os.File) (int64, error) {
+	return 0, errors.New("block devices not supported on windows")
+}
+
 // getSectorSizes get the logical and physical sector sizes for a block device
 func getSectorSizes(f *os.File) (int64, int64, error) {
 	return 0, 0, errors.New("block devices not supported on windows")


### PR DESCRIPTION
Currently, diskfs attempts to detect the size of a block device using a
"seek" based approach. Unfortunately, while this looks generic, it does
not work on Mac, at least not in a VM.

Based on the previous commit, this commit adds a Mac and Linux
implementation for getting the size of a Block device through IOCTL
inspired by https://github.com/tytso/e2fsprogs/blob/master/lib/ext2fs/getsize.c

This was manually tested using a Linux loopback device and in a Mac
virtual machine.