### PR TITLE
Replace os.Chdir logic in ISO9660 with absolute paths to allow for concurrent use

### DIFF
--- a/filesystem/iso9660/rockridge.go
+++ b/filesystem/iso9660/rockridge.go
@@ -184,7 +184,7 @@ func (r *rockRidgeExtension) UsePathtable() bool {
 // Relocate restructure so that all directories are at a depth of 8 or fewer
 func (r *rockRidgeExtension) Relocate(dirs map[string]*finalizeFileInfo) ([]*finalizeFileInfo, map[string]*finalizeFileInfo, error) {
 	files := make([]*finalizeFileInfo, 0)
-	root := dirs["."]
+	root := dirs["/"]
 	relocationDir := root
 	if relocationDir.depth == 8 {
 		return nil, nil, fmt.Errorf("cannot relocate when relocation parent already is max depth 8")


### PR DESCRIPTION
Hello,

I have a use case where I create multiple ISO files concurrently with different contents and names.

The `os.Chdir()` call changes the working dir for the entire app. Having multiple go routines that call the function does end up in a race condition which has the correct working dir.

This patch uses absolute paths and does not rely on the working directory to be changed.

Thanks for maintaining the package!