### PR TITLE
WIP: fs.FS support

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -327,6 +327,32 @@ func Open(device string, opts ...OpenOpt) (*disk.Disk, error) {
 	return initDisk(f, ReadWriteExclusive, opt.sectorSize)
 }
 
+func OpenFile(f *os.File, opts ...OpenOpt) (*disk.Disk, error) {
+	// err := checkDevice(device)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	opt := openOptsDefaults()
+	for _, o := range opts {
+		if err := o(opt); err != nil {
+			return nil, err
+		}
+	}
+
+	// m, ok := openModeOptions[opt.mode]
+	// if !ok {
+	// 	return nil, errors.New("unsupported file open mode")
+	// }
+
+	// f, err := os.OpenFile(device, m, 0o600)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("could not open device %s exclusively for writing", device)
+	// }
+	// return our disk
+	return initDisk(f, ReadWriteExclusive, opt.sectorSize)
+}
+
 // Create a Disk from a path to a device
 // Should pass a path to a block device e.g. /dev/sda or a path to a file /tmp/foo.img
 // The provided device must not exist at the time you call Create()

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -3,6 +3,7 @@ package fat32
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"sort"
@@ -61,6 +62,10 @@ type FileSystem struct {
 	size            int64
 	start           int64
 	file            util.File
+}
+
+func (fs *FileSystem) Open(name string) (fs.File, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 // Equal compare if two filesystems are equal

--- a/filesystem/fat32/file.go
+++ b/filesystem/fat32/file.go
@@ -3,6 +3,7 @@ package fat32
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 )
 
@@ -14,6 +15,14 @@ type File struct {
 	offset      int64
 	parent      *Directory
 	filesystem  *FileSystem
+}
+
+func (fl *File) ReadDir(n int) ([]fs.DirEntry, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (fl *File) Stat() (fs.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 // Read reads up to len(b) bytes from the File.

--- a/filesystem/file.go
+++ b/filesystem/file.go
@@ -1,11 +1,15 @@
 package filesystem
 
-import "io"
+import (
+	"io"
+	"io/fs"
+)
 
 // File a reference to a single file on disk
 type File interface {
-	io.ReadWriteSeeker
-	io.Closer
+	fs.ReadDirFile
+	io.Writer
+	io.Seeker
 	// io.ReaderAt
 	// io.WriterAt
 }

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -3,11 +3,13 @@
 package filesystem
 
 import (
+	"io/fs"
 	"os"
 )
 
 // FileSystem is a reference to a single filesystem on a disk
 type FileSystem interface {
+	Open(name string) (fs.File, error)
 	// Type return the type of filesystem
 	Type() Type
 	// Mkdir make a directory

--- a/filesystem/iso9660/file.go
+++ b/filesystem/iso9660/file.go
@@ -3,6 +3,7 @@ package iso9660
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 )
 
@@ -15,6 +16,27 @@ type File struct {
 	isAppend    bool
 	offset      int64
 	closed      bool
+	fullname    string
+}
+
+func (fl File) ReadDir(n int) ([]fs.DirEntry, error) {
+	if !fl.IsDir() {
+		return nil, fs.ErrNotExist
+	}
+	var res []fs.DirEntry
+
+	if entries, err := fl.filesystem.readDirectory(fl.fullname); err == nil {
+		for _, de := range entries {
+			res = append(res, fs.FileInfoToDirEntry(de))
+		}
+		return res, nil
+	} else {
+		return nil, err
+	}
+}
+
+func (fl File) Stat() (fs.FileInfo, error) {
+	return fl.directoryEntry, nil
 }
 
 // Read reads up to len(b) bytes from the File.

--- a/filesystem/squashfs/file.go
+++ b/filesystem/squashfs/file.go
@@ -3,6 +3,7 @@ package squashfs
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 )
 
@@ -17,6 +18,14 @@ type File struct {
 	isAppend    bool
 	offset      int64
 	filesystem  *FileSystem
+}
+
+func (fl *File) ReadDir(n int) ([]fs.DirEntry, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (fl *File) Stat() (fs.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 // Read reads up to len(b) bytes from the File.

--- a/filesystem/squashfs/squashfs.go
+++ b/filesystem/squashfs/squashfs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path"
@@ -32,6 +33,10 @@ type FileSystem struct {
 	uidsGids   []uint32
 	xattrs     *xAttrTable
 	rootDir    inode
+}
+
+func (fs *FileSystem) Open(name string) (fs.File, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 // Equal compare if two filesystems are equal


### PR DESCRIPTION
@deitch please find my first effors of implementing fs.FS here. Only iso9660 is supported as yet.

For me, there it is a dilemma: either to break the api and implement whole fs.FS support or implement wrapper functions. Wrappers look clumsily and, either way, require modifications of existing functions...

As for newly created `diskfs.OpenFile`, I've made it during my efforts of fiddling with "multi-layered fs.FS", i.e. say, I have a `DirFS`, where I call fs.Open yeiding an `fs.File`, which I pass to `diskfs.OpenFile` to get to the next layer. Again, it's not very handy, as `diskfs.initDisk` requires `os.File` - another "why" in my journey..

closes #169