### PR TITLE
create filesystem on partition 1

### DIFF
--- a/examples/efi_create.go
+++ b/examples/efi_create.go
@@ -43,7 +43,7 @@ func CreateEfi(diskImg string) {
 	 */
 	kernel, err := os.ReadFile("/some/kernel/file")
 
-	spec := diskpkg.FilesystemSpec{Partition: 0, FSType: filesystem.TypeFat32}
+	spec := diskpkg.FilesystemSpec{Partition: 1, FSType: filesystem.TypeFat32}
 	fs, err := disk.CreateFilesystem(spec)
 
 	// make our directories


### PR DESCRIPTION
Fixes #180 

It was creating it on partition "0", which means the whole disk.