### PR TITLE
partition: add repair capabilities to GPT

### DIFF
--- a/partition/mbr/table.go
+++ b/partition/mbr/table.go
@@ -176,3 +176,13 @@ func (t *Table) GetPartitions() []part.Partition {
 	}
 	return parts
 }
+
+// Verify will attempt to evaluate the headers
+func (t *Table) Verify(f util.File, diskSize uint64) error {
+	return nil
+}
+
+// Repair will attempt to repair a broken Master Boot Record
+func (t *Table) Repair(diskSize uint64) error {
+	return nil
+}

--- a/partition/table.go
+++ b/partition/table.go
@@ -10,4 +10,6 @@ type Table interface {
 	Type() string
 	Write(util.File, int64) error
 	GetPartitions() []part.Partition
+	Repair(diskSize uint64) error
+	Verify(f util.File, diskSize uint64) error
 }


### PR DESCRIPTION
Based on #112, and addressing review comments. Thanks to the original author! @thebsdbox

1. add Repair and Verify interfaces in type table
2. add test to test opening the GPT image