### PR TITLE
Open disk in O_SYNC mode when writing

### DIFF
--- a/diskfs.go
+++ b/diskfs.go
@@ -158,8 +158,8 @@ func (m OpenModeOption) String() string {
 
 var openModeOptions = map[OpenModeOption]int{
 	ReadOnly:           os.O_RDONLY,
-	ReadWriteExclusive: os.O_RDWR | os.O_EXCL,
-	ReadWrite:          os.O_RDWR,
+	ReadWriteExclusive: os.O_RDWR | os.O_EXCL | os.O_SYNC,
+	ReadWrite:          os.O_RDWR | os.O_SYNC,
 }
 
 // SectorSize represents the sector size to use


### PR DESCRIPTION
I've had some intermittent issues with some NVMe disks ignoring the partitions I was writing with `diskfs.Partition` and immediately reading them back.
No amount of `syscalls.Sync` would make the issues go away, but changing the writing mode to `O_SYNC` did help.

