### PR TITLE
squashfs: fix off by one in directory counting

### DIFF
--- a/filesystem/squashfs/directory.go
+++ b/filesystem/squashfs/directory.go
@@ -64,8 +64,8 @@ func parseDirectory(b []byte) (*directory, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not parse directory header: %v", err)
 		}
-		if directoryHeader.count+1 > maxDirEntries {
-			return nil, fmt.Errorf("corrupted directory, had %d entries instead of max %d", directoryHeader.count+1, maxDirEntries)
+		if directoryHeader.count > maxDirEntries {
+			return nil, fmt.Errorf("corrupted directory, had %d entries instead of max %d", directoryHeader.count, maxDirEntries)
 		}
 		pos += dirHeaderSize
 		for count := uint32(0); count < directoryHeader.count; count++ {


### PR DESCRIPTION
This was causing "corrupted directory, had 257 entries instead of max
256" errors, however this was because parseDirectoryHeader had already
added one to the count.
