### PR TITLE
squashfs: sometimes missing xattrs seems to be marked with 0xffffffffffffffff

### DIFF
--- a/filesystem/squashfs/squashfs.go
+++ b/filesystem/squashfs/squashfs.go
@@ -160,7 +160,7 @@ func Read(file util.File, size, start, blocksize int64) (*FileSystem, error) {
 	var (
 		xattrs *xAttrTable
 	)
-	if !s.noXattrs {
+	if !s.noXattrs && s.xattrTableStart != 0xffff_ffff_ffff_ffff {
 		// xattr is right to the end of the disk
 		xattrs, err = readXattrsTable(s, file, compress)
 		if err != nil {


### PR DESCRIPTION
Using mksquashfs 1:4.5-3build1 and these flags causes the created
squash file not have xattrs but this is indicated by the index being
all 1s rather than the flag in the superblock.

mksquashfs $IMG $IMG.sqfs -comp zstd -Xcompression-level 3 -b 1M -no-xattrs -all-root
