### PR TITLE
squashfs: implement a way to read the target of symlinks

### DIFF
--- a/filesystem/squashfs/const_internal_test.go
+++ b/filesystem/squashfs/const_internal_test.go
@@ -220,14 +220,14 @@ func testGetFilesystemRoot() []*directoryEntry {
 	// data taken from reading the bytes of the file SquashfsUncompressedfile
 	modTime := time.Unix(0x5c20d8d7, 0)
 	return []*directoryEntry{
-		{true, "foo", 9949, modTime, 0o755, nil, FileStat{0, 0, map[string]string{}}},
-		{true, "zero", 32, modTime, 0o755, nil, FileStat{0, 0, map[string]string{}}},
-		{true, "random", 32, modTime, 0o755, nil, FileStat{0, 0, map[string]string{}}},
-		{false, "emptylink", 0, modTime, 0o777, nil, FileStat{0, 0, map[string]string{}}},
-		{false, "goodlink", 0, modTime, 0o777, nil, FileStat{0, 0, map[string]string{}}},
-		{false, "hardlink", 7, modTime, 0o644, nil, FileStat{1, 2, map[string]string{}}},
-		{false, "README.md", 7, modTime, 0o644, nil, FileStat{1, 2, map[string]string{}}},
-		{false, "attrfile", 5, modTime, 0o644, nil, FileStat{0, 0, map[string]string{"abc": "def", "myattr": "hello"}}},
+		{true, "foo", 9949, modTime, 0o755, nil, 0, 0, map[string]string{}},
+		{true, "zero", 32, modTime, 0o755, nil, 0, 0, map[string]string{}},
+		{true, "random", 32, modTime, 0o755, nil, 0, 0, map[string]string{}},
+		{false, "emptylink", 0, modTime, 0o777, nil, 0, 0, map[string]string{}},
+		{false, "goodlink", 0, modTime, 0o777, nil, 0, 0, map[string]string{}},
+		{false, "hardlink", 7, modTime, 0o644, nil, 1, 2, map[string]string{}},
+		{false, "README.md", 7, modTime, 0o644, nil, 1, 2, map[string]string{}},
+		{false, "attrfile", 5, modTime, 0o644, nil, 0, 0, map[string]string{"abc": "def", "myattr": "hello"}},
 	}
 }
 

--- a/filesystem/squashfs/directoryentry.go
+++ b/filesystem/squashfs/directoryentry.go
@@ -6,45 +6,7 @@ import (
 )
 
 // FileStat is the extended data underlying a single file, similar to https://golang.org/pkg/syscall/#Stat_t
-type FileStat struct {
-	uid    uint32
-	gid    uint32
-	xattrs map[string]string
-}
-
-func (f *FileStat) equal(o *FileStat) bool {
-	if f.uid != o.uid || f.gid != o.gid {
-		return false
-	}
-	if len(f.xattrs) != len(o.xattrs) {
-		return false
-	}
-	for k, v := range f.xattrs {
-		ov, ok := o.xattrs[k]
-		if !ok {
-			return false
-		}
-		if ov != v {
-			return false
-		}
-	}
-	return true
-}
-
-// UID get uid of file
-func (f *FileStat) UID() uint32 {
-	return f.uid
-}
-
-// GID get gid of file
-func (f *FileStat) GID() uint32 {
-	return f.gid
-}
-
-// Xattrs get extended attributes of file
-func (f *FileStat) Xattrs() map[string]string {
-	return f.xattrs
-}
+type FileStat = *directoryEntry
 
 // directoryEntry is a single directory entry
 // it combines information from inode and the actual entry
@@ -63,14 +25,13 @@ type directoryEntry struct {
 	modTime        time.Time
 	mode           os.FileMode
 	inode          inode
-	sys            FileStat
+	uid            uint32
+	gid            uint32
+	xattrs         map[string]string
 }
 
 func (d *directoryEntry) equal(o *directoryEntry) bool {
 	if o == nil {
-		return false
-	}
-	if !d.sys.equal(&o.sys) {
 		return false
 	}
 	if d.inode == nil && o.inode == nil {
@@ -151,5 +112,20 @@ func (d *directoryEntry) Mode() os.FileMode {
 
 // Sys interface{}   // underlying data source (can return nil)
 func (d *directoryEntry) Sys() interface{} {
-	return d.sys
+	return d
+}
+
+// UID get uid of file
+func (d *directoryEntry) UID() uint32 {
+	return d.uid
+}
+
+// GID get gid of file
+func (d *directoryEntry) GID() uint32 {
+	return d.gid
+}
+
+// Xattrs get extended attributes of file
+func (d *directoryEntry) Xattrs() map[string]string {
+	return d.xattrs
 }

--- a/filesystem/squashfs/directoryentry_internal_test.go
+++ b/filesystem/squashfs/directoryentry_internal_test.go
@@ -1,6 +1,7 @@
 package squashfs
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -12,6 +13,9 @@ func TestDirectoryEntry(t *testing.T) {
 		size:           8675309,
 		modTime:        time.Now(),
 		mode:           0o766,
+		uid:            32,
+		gid:            33,
+		xattrs:         map[string]string{"test": "value"},
 	}
 	switch {
 	case de.Name() != de.name:
@@ -28,23 +32,20 @@ func TestDirectoryEntry(t *testing.T) {
 		t.Errorf("Mismatched Sys(), unexpected nil")
 	}
 	// check that Sys() is convertible
-	if _, ok := de.Sys().(FileStat); !ok {
+	fs, ok := de.Sys().(FileStat)
+	if !ok {
 		t.Errorf("Mismatched Sys(), could not convert to FileStat")
 	}
-}
-
-func TestFileStatUID(t *testing.T) {
-	fs := FileStat{uid: 32}
 	uid := fs.UID()
 	if uid != fs.uid {
 		t.Errorf("Mismatched UID, actual %d expected %d", uid, fs.uid)
 	}
-}
-
-func TestFileStatGID(t *testing.T) {
-	fs := FileStat{gid: 32}
 	gid := fs.GID()
 	if gid != fs.gid {
 		t.Errorf("Mismatched GID, actual %d expected %d", gid, fs.gid)
+	}
+	xattrs := fs.Xattrs()
+	if !reflect.DeepEqual(xattrs, fs.xattrs) {
+		t.Errorf("Mismatched Xattrs, actual %+v expected %+v", xattrs, fs.xattrs)
 	}
 }

--- a/filesystem/squashfs/squashfs.go
+++ b/filesystem/squashfs/squashfs.go
@@ -446,11 +446,9 @@ func (fs *FileSystem) hydrateDirectoryEntries(entries []*directoryEntryRaw) ([]*
 			modTime:        header.modTime,
 			mode:           header.mode,
 			inode:          in,
-			sys: FileStat{
-				uid:    fs.uidsGids[header.uidIdx],
-				gid:    fs.uidsGids[header.gidIdx],
-				xattrs: xattrs,
-			},
+			uid:            fs.uidsGids[header.uidIdx],
+			gid:            fs.uidsGids[header.gidIdx],
+			xattrs:         xattrs,
 		})
 	}
 	return fullEntries, nil


### PR DESCRIPTION
This implements a way to read the target of symlinks as discussed in #200 

It is divided into two parts, the first a bit of refactoring, then the second the implementation of the new method.

- squashfs: move UID(),GID(),Xattr() methods to directory entry #200
- squashfs: implement Readlink() method on directory entry
