### PR TITLE
Fix off-by-one error in GPT last data sector

### DIFF
--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -106,7 +106,7 @@ func (t *Table) initTable(size int64) {
 		t.secondaryHeader = diskSectors - 1
 	}
 	if t.lastDataSector == 0 {
-		t.lastDataSector = diskSectors - 1 - partSectors
+		t.lastDataSector = t.secondaryHeader - partSectors - 1
 	}
 
 	t.initialized = true


### PR DESCRIPTION
The last usable data sector should be the sector of the start of the backup partition table - 1, but it does not subtract the 1. This fixes it and adds an additional test with sgdisk to verify.