### PR TITLE
Removed go.uuid dependency

### DIFF
--- a/filesystem/ext4/common_test.go
+++ b/filesystem/ext4/common_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 const (
@@ -180,7 +180,7 @@ var testSuperblockFuncs = map[string]testSuperblockFunc{
 		return nil
 	},
 	"Filesystem UUID": func(sb *superblock, value string) error {
-		uuid, err := uuid.FromString(value)
+		uuid, err := uuid.Parse(value)
 		if err != nil {
 			return err
 		}
@@ -417,11 +417,11 @@ var testSuperblockFuncs = map[string]testSuperblockFunc{
 		return nil
 	},
 	"Directory Hash Seed": func(sb *superblock, value string) error {
-		u, err := uuid.FromString(value)
+		u, err := uuid.Parse(value)
 		if err != nil {
 			return err
 		}
-		hashTreeSeedBytes := u.Bytes()
+		hashTreeSeedBytes := u[:]
 		hashTreeSeed := make([]uint32, 4)
 		for i := 0; i < 4; i++ {
 			hashTreeSeed[i] = binary.LittleEndian.Uint32(hashTreeSeedBytes[i*4 : (i+1)*4])

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -13,7 +13,7 @@ import (
 	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/diskfs/go-diskfs/filesystem/ext4/crc"
 	"github.com/diskfs/go-diskfs/util"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // SectorSize indicates what the sector size in bytes is
@@ -149,7 +149,7 @@ func Create(f util.File, size, start, sectorsize int64, p *Params) (*FileSystem,
 	// uuid
 	fsuuid := p.UUID
 	if fsuuid == nil {
-		fsuuid2 := uuid.NewV4()
+		fsuuid2, _ := uuid.NewRandom()
 		fsuuid = &fsuuid2
 	}
 
@@ -360,8 +360,8 @@ func Create(f util.File, size, start, sectorsize int64, p *Params) (*FileSystem,
 	mflags := defaultMiscFlags
 
 	// generate hash seed
-	hashSeed := uuid.NewV4()
-	hashSeedBytes := hashSeed.Bytes()
+	hashSeed, _ := uuid.NewRandom()
+	hashSeedBytes := hashSeed[:]
 	htreeSeed := make([]uint32, 0, 4)
 	htreeSeed = append(htreeSeed,
 		binary.LittleEndian.Uint32(hashSeedBytes[:4]),
@@ -371,7 +371,7 @@ func Create(f util.File, size, start, sectorsize int64, p *Params) (*FileSystem,
 	)
 
 	// create a UUID for the journal
-	journalSuperblockUUID := uuid.NewV4()
+	journalSuperblockUUID, _ := uuid.NewRandom()
 
 	// group descriptor size could be 32 or 64, depending on option
 	var gdSize uint16
@@ -514,7 +514,7 @@ func Create(f util.File, size, start, sectorsize int64, p *Params) (*FileSystem,
 		backupSuperblockBlockGroups:  backupSuperblockGroupsSparse,
 		lostFoundInode:               lostFoundInode,
 		overheadBlocks:               0,
-		checksumSeed:                 crc.CRC32c(0, fsuuid.Bytes()), // according to docs, this should be crc32c(~0, $orig_fs_uuid)
+		checksumSeed:                 crc.CRC32c(0, fsuuid[:]), // according to docs, this should be crc32c(~0, $orig_fs_uuid)
 		snapshotInodeNumber:          0,
 		snapshotID:                   0,
 		snapshotReservedBlocks:       0,

--- a/filesystem/ext4/superblock.go
+++ b/filesystem/ext4/superblock.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/diskfs/go-diskfs/filesystem/ext4/crc"
 	"github.com/diskfs/go-diskfs/util"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 type filesystemState uint16
@@ -430,7 +430,7 @@ func superblockFromBytes(b []byte) (*superblock, error) {
 	sb.checksumSeed = binary.LittleEndian.Uint32(b[0x270:0x274])
 	// what if the seed is missing? It can be.
 	if sb.features.metadataChecksums && sb.checksumSeed == 0 {
-		sb.checksumSeed = crc.CRC32c(0xffffffff, sb.uuid.Bytes())
+		sb.checksumSeed = crc.CRC32c(0xffffffff, sb.uuid[:])
 	}
 
 	sb.filenameCharsetEncoding = binary.LittleEndian.Uint16(b[0x27c:0x27e])
@@ -546,7 +546,7 @@ func (sb *superblock) toBytes() ([]byte, error) {
 	binary.LittleEndian.PutUint16(b[0x5a:0x5c], sb.blockGroup)
 
 	if sb.uuid != nil {
-		copy(b[0x68:0x78], sb.uuid.Bytes())
+		copy(b[0x68:0x78], sb.uuid[:])
 	}
 
 	ab, err := stringToASCIIBytes(sb.volumeLabel, 16)
@@ -567,7 +567,7 @@ func (sb *superblock) toBytes() ([]byte, error) {
 	binary.LittleEndian.PutUint16(b[0xce:0xd0], sb.reservedGDTBlocks)
 
 	if sb.journalSuperblockUUID != nil {
-		copy(b[0xd0:0xe0], sb.journalSuperblockUUID.Bytes())
+		copy(b[0xd0:0xe0], sb.journalSuperblockUUID[:])
 	}
 
 	binary.LittleEndian.PutUint32(b[0xe0:0xe4], sb.journalInode)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pierrec/lz4/v4 v4.1.17
 	github.com/pkg/xattr v0.4.9
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	github.com/ulikunitz/xz v0.5.11
 	golang.org/x/sys v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
 github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af h1:Sp5TG9f7K39yfB+If0vjp97vuT74F72r8hfRpP8jLU0=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -31,7 +29,6 @@ golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
github.com/google/uuid was already a dependency so I removed the github.com/satori/go.uuid dependency that was introduced recently 

satori/go.uuid looks to be no longer maintained as of 2018
