### PR TITLE
Allow resizing a GPT

### DIFF
--- a/partition/gpt/partition.go
+++ b/partition/gpt/partition.go
@@ -296,3 +296,9 @@ func (p *Partition) Equal(o *Partition) bool {
 func (p *Partition) UUID() string {
 	return p.GUID
 }
+
+// Expand increases the size of the partition by a number of sectors
+func (p *Partition) Expand(sectors uint64) {
+	p.End += sectors
+	p.Size += sectors * uint64(p.logicalSectorSize)
+}

--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -12,6 +12,28 @@ import (
 	uuid "github.com/google/uuid"
 )
 
+// TotalSize returns the total size of the GPT in bytes.
+//
+// This is counted from the start of the MBR to the end of the secondary
+// header.
+func (t *Table) TotalSize() uint64 {
+	return (t.secondaryHeader + gptHeaderSector) * uint64(t.LogicalSectorSize)
+}
+
+func (t *Table) LastDataSector() uint64 {
+	return t.lastDataSector
+}
+
+func (t *Table) Resize(size uint64) {
+	// how many sectors on the disk?
+	diskSectors := size / uint64(t.LogicalSectorSize)
+	// how many sectors used for partition entries?
+	partSectors := uint64(t.partitionArraySize) * uint64(t.partitionEntrySize) / uint64(t.LogicalSectorSize)
+
+	t.secondaryHeader = diskSectors - 1
+	t.lastDataSector = diskSectors - 1 - partSectors
+}
+
 // gptSize max potential size for partition array reserved 16384
 const (
 	mbrPartitionEntriesStart = 446
@@ -20,6 +42,7 @@ const (
 	// just defaults
 	physicalSectorSize = 512
 	logicalSectorSize  = 512
+	gptHeaderSector    = 1
 )
 
 // Table represents a partition table to be applied to a disk or read from a disk

--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -24,6 +24,12 @@ func (t *Table) LastDataSector() uint64 {
 	return t.lastDataSector
 }
 
+// Resize changes the size of the GPT.
+//
+// The size argument is in bytes and must be a multiple of the logical sector
+// size.
+// Use this function in case a storage device is not the same as the total
+// size of its GPT.
 func (t *Table) Resize(size uint64) {
 	// how many sectors on the disk?
 	diskSectors := size / uint64(t.LogicalSectorSize)

--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -12,34 +12,6 @@ import (
 	uuid "github.com/google/uuid"
 )
 
-// TotalSize returns the total size of the GPT in bytes.
-//
-// This is counted from the start of the MBR to the end of the secondary
-// header.
-func (t *Table) TotalSize() uint64 {
-	return (t.secondaryHeader + gptHeaderSector) * uint64(t.LogicalSectorSize)
-}
-
-func (t *Table) LastDataSector() uint64 {
-	return t.lastDataSector
-}
-
-// Resize changes the size of the GPT.
-//
-// The size argument is in bytes and must be a multiple of the logical sector
-// size.
-// Use this function in case a storage device is not the same as the total
-// size of its GPT.
-func (t *Table) Resize(size uint64) {
-	// how many sectors on the disk?
-	diskSectors := size / uint64(t.LogicalSectorSize)
-	// how many sectors used for partition entries?
-	partSectors := uint64(t.partitionArraySize) * uint64(t.partitionEntrySize) / uint64(t.LogicalSectorSize)
-
-	t.secondaryHeader = diskSectors - 1
-	t.lastDataSector = t.secondaryHeader - 1 - partSectors
-}
-
 // gptSize max potential size for partition array reserved 16384
 const (
 	mbrPartitionEntriesStart = 446
@@ -668,4 +640,32 @@ func (t *Table) Repair(diskSize uint64) error {
 	t.lastDataSector = t.secondaryHeader - partSectors - 1
 
 	return nil
+}
+
+// TotalSize returns the total size of the GPT in bytes.
+//
+// This is counted from the start of the MBR to the end of the secondary
+// header.
+func (t *Table) TotalSize() uint64 {
+	return (t.secondaryHeader + gptHeaderSector) * uint64(t.LogicalSectorSize)
+}
+
+func (t *Table) LastDataSector() uint64 {
+	return t.lastDataSector
+}
+
+// Resize changes the size of the GPT.
+//
+// The size argument is in bytes and must be a multiple of the logical sector
+// size.
+// Use this function in case a storage device is not the same as the total
+// size of its GPT.
+func (t *Table) Resize(size uint64) {
+	// how many sectors on the disk?
+	diskSectors := size / uint64(t.LogicalSectorSize)
+	// how many sectors used for partition entries?
+	partSectors := uint64(t.partitionArraySize) * uint64(t.partitionEntrySize) / uint64(t.LogicalSectorSize)
+
+	t.secondaryHeader = diskSectors - 1
+	t.lastDataSector = t.secondaryHeader - 1 - partSectors
 }

--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -31,7 +31,7 @@ func (t *Table) Resize(size uint64) {
 	partSectors := uint64(t.partitionArraySize) * uint64(t.partitionEntrySize) / uint64(t.LogicalSectorSize)
 
 	t.secondaryHeader = diskSectors - 1
-	t.lastDataSector = diskSectors - 1 - partSectors
+	t.lastDataSector = t.secondaryHeader - 1 - partSectors
 }
 
 // gptSize max potential size for partition array reserved 16384


### PR DESCRIPTION
These changes allow:
* observing the total size and last data sector of a GPT
* resizing a GPT (for example to make it fit its block device)
* expanding a GPT partition