### PR TITLE
get more accurate read of ext4 superblock in tests

### DIFF
--- a/filesystem/ext4/testdata/buildimg.sh
+++ b/filesystem/ext4/testdata/buildimg.sh
@@ -41,4 +41,5 @@ dd if=ext4.img of=gdt.bin bs=1024 count=1 skip=2
 dd if=ext4.img of=superblock.bin bs=1024 count=1 skip=1
 dd if=superblock.bin bs=1 skip=208 count=16 2>/dev/null | hexdump -e '16/1 "%02x" "\n"' > journaluuid.txt
 dd if=superblock.bin   bs=1 skip=$((0x10c)) count=$((15 * 4)) | hexdump -e '15/4 "0x%08x, " "\n"' > journalinodex.txt
+dd if=superblock.bin count=2 skip=376 bs=1 2>/dev/null| hexdump -e '1/2 "%u"' > lifetime_kb.txt
 EOF


### PR DESCRIPTION
The tests were using `dumpe2fs`/`debugfs -R "stats"` (same thing) to get information about the superblock to use for tests. Mostly that works, except for lifetime writes. That is rounded to MB, which makes it difficult to get the correct number, and sometimes is wrong, which makes the 2 bytes in the calculation incorrect, and makes the checksum wrong.

This instead reads the specific bytes from the superblock via `dd` and uses that as the accurate number.