### PR TITLE
iso9660 and squashfs support for parallel writings

### DIFF
--- a/filesystem/squashfs/finalize.go
+++ b/filesystem/squashfs/finalize.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -415,21 +416,24 @@ func finalizeFragment(buf []byte, to util.File, toOffset int64, c Compressor) (r
 // because the inode data is different.
 // The first entry in the return always will be the root
 func walkTree(workspace string) ([]*finalizeFileInfo, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("could not get pwd: %v", err)
-	}
-	// make everything relative to the workspace
-	_ = os.Chdir(workspace)
 	dirMap := make(map[string]*finalizeFileInfo)
 	fileList := make([]*finalizeFileInfo, 0)
 	var entry *finalizeFileInfo
-	_ = filepath.Walk(".", func(fp string, fi os.FileInfo, err error) error {
+	err := filepath.WalkDir(workspace, func(actualPath string, d iofs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
+		fp := strings.TrimPrefix(actualPath, workspace)
+		fp = strings.TrimPrefix(fp, string(filepath.Separator))
+		if fp == "" {
+			fp = "."
+		}
 		isRoot := fp == "."
-		name := fi.Name()
+		name := d.Name()
+		fi, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("could not get file info for %s: %v", fp, err)
+		}
 		m := fi.Mode()
 		var fType fileType
 		switch {
@@ -448,7 +452,7 @@ func walkTree(workspace string) ([]*finalizeFileInfo, error) {
 		default:
 			fType = fileRegular
 		}
-		xattrNames, err := xattr.List(fp)
+		xattrNames, err := xattr.List(actualPath)
 		if err != nil {
 			return fmt.Errorf("unable to list xattrs for %s: %v", fp, err)
 		}
@@ -495,8 +499,9 @@ func walkTree(workspace string) ([]*finalizeFileInfo, error) {
 		fileList = append(fileList, entry)
 		return nil
 	})
-	// reset the workspace
-	_ = os.Chdir(cwd)
+	if err != nil {
+		return nil, err
+	}
 
 	return fileList, nil
 }


### PR DESCRIPTION
Fixes #244 

The iso finalization originally was written without parallelism in mind. Most of it works fine. The inly issue was walking the workspace to finalize. Because it is easier to work with relative paths, it did a `os.Chdir(workspace)` followed by a `filepath.Walk(".",...)`. In most cases, this works fine, but if you run in parallel, different threads start changing the current directory and mess up things like creating files or removing files or walking trees.

In general, `os.Chdir()` is not a friendly thing to do in libraries, so it is good to remove it.

Both iso9660 and squashfs did this, so fixed in both places.

Thanks to @mchuang3 for the excellent issue in #244, with a simple recreation.