### PR TITLE
gpt: point alternate PartitionEntryLBA to alternate GPT table

### DIFF
--- a/partition/gpt/table.go
+++ b/partition/gpt/table.go
@@ -295,7 +295,7 @@ func (t *Table) toGPTBytes(primary bool) ([]byte, error) {
 	copy(b[56:72], bytesToUUIDBytes(guid[0:16]))
 
 	// starting LBA of array of partition entries
-	binary.LittleEndian.PutUint64(b[72:80], t.partitionArraySector(true))
+	binary.LittleEndian.PutUint64(b[72:80], t.partitionArraySector(primary))
 
 	// how many entries?
 	binary.LittleEndian.PutUint32(b[80:84], uint32(t.partitionArraySize))


### PR DESCRIPTION
Currently both tables point to the primary GPT partition entry array which doesn't make a lot of sense. Pass "primary" to t.partitionArraySector() to get the right address for each of the tables instead.

I found this because I was building images for a Chrombook and noticed that [cgpt](https://packages.ubuntu.com/oracular/cgpt) always reported the secondary GPT header as corrupted. 

For comparison here is the `cgpt show` output without this fix for a minimal ESP example:
```
       start        size    part  contents
           0           1          PMBR
           1           1          Pri GPT header
                                  Sig: [EFI PART]
                                  Rev: 0x00010000
                                  Size: 92 (blocks)
                                  Header CRC: 0x56d22730 
                                  My LBA: 1
                                  Alternate LBA: 212991
                                  First LBA: 34
                                  Last LBA: 212958
                                  Disk UUID: F4206CB2-52F5-4BEA-B903-62A6CC3DDAFB
                                  Entries LBA: 2
                                  Number of entries: 128
                                  Size of entry: 128
                                  Entries CRC: 0xc5a89a28 
           2          32          Pri GPT table
        2048      200706       1  Label: "EFI System"
                                  Type: EFI System Partition
                                  UUID: C2BDE81C-A933-421E-B854-A86FFD229D8E
           2          32 INVALID  Sec GPT table
           1           1 INVALID  Sec GPT header
                                  Sig: [EFI PART]
                                  Rev: 0x00010000
                                  Size: 92 (blocks)
                                  Header CRC: 0x995343f3 
                                  My LBA: 212991
                                  Alternate LBA: 1
                                  First LBA: 34
                                  Last LBA: 212958
                                  Disk UUID: F4206CB2-52F5-4BEA-B903-62A6CC3DDAFB
                                  Entries LBA: 2
                                  Number of entries: 128
                                  Size of entry: 128
                                  Entries CRC: 0xc5a89a28 INVALID
```

And in comparison the fixed version with the secondary table pointing to the secondary partition list:
```
       start        size    part  contents
           0           1          PMBR
           1           1          Pri GPT header
                                  Sig: [EFI PART]
                                  Rev: 0x00010000
                                  Size: 92 (blocks)
                                  Header CRC: 0x2dd2b955 
                                  My LBA: 1
                                  Alternate LBA: 212991
                                  First LBA: 34
                                  Last LBA: 212958
                                  Disk UUID: EF0BACC6-F30A-4455-9E3E-96AE05F78C6A
                                  Entries LBA: 2
                                  Number of entries: 128
                                  Size of entry: 128
                                  Entries CRC: 0x31d5ac19 
           2          32          Pri GPT table
        2048      200706       1  Label: "EFI System"
                                  Type: EFI System Partition
                                  UUID: 22712D7B-7398-4E20-8484-1FF7F73C3233
      212959          32          Sec GPT table
        2048      200706       1  Label: "EFI System"
                                  Type: EFI System Partition
                                  UUID: 22712D7B-7398-4E20-8484-1FF7F73C3233
      212991           1          Sec GPT header
                                  Sig: [EFI PART]
                                  Rev: 0x00010000
                                  Size: 92 (blocks)
                                  Header CRC: 0x76129696 
                                  My LBA: 212991
                                  Alternate LBA: 1
                                  First LBA: 34
                                  Last LBA: 212958
                                  Disk UUID: EF0BACC6-F30A-4455-9E3E-96AE05F78C6A
                                  Entries LBA: 212959
                                  Number of entries: 128
                                  Size of entry: 128
                                  Entries CRC: 0x31d5ac19 
```