### PR TITLE
Closes #250: fat32 8.3 lowercase names, make fs.OpenFile case insensitive for 8.3 and long filenames

### DIFF
--- a/filesystem/fat32/directoryentry.go
+++ b/filesystem/fat32/directoryentry.go
@@ -103,7 +103,7 @@ func (de *directoryEntry) toBytes() ([]byte, error) {
 	}
 
 	if de.lowercaseExtension {
-		dosBytes[12] |= 0x04
+		dosBytes[12] |= 0x10
 	}
 	if de.lowercaseShortname {
 		dosBytes[12] |= 0x08
@@ -161,7 +161,7 @@ byteLoop:
 		isArchiveDirty := b[i+11]&0x20 == 0x20
 		isVolumeLabel := b[i+11]&0x08 == 0x08
 		lowercaseShortname := b[i+12]&0x08 == 0x08
-		lowercaseExtension := b[i+12]&0x04 == 0x04
+		lowercaseExtension := b[i+12]&0x10 == 0x10
 
 		entry := directoryEntry{
 			filenameLong:       lfn,

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -511,7 +511,7 @@ func (fs *FileSystem) ReadDir(p string) ([]os.FileInfo, error) {
 		}
 		fileExtension := e.fileExtension
 		if e.lowercaseExtension {
-			shortName = strings.ToLower(fileExtension)
+			fileExtension = strings.ToLower(fileExtension)
 		}
 		if fileExtension != "" {
 			shortName = fmt.Sprintf("%s.%s", shortName, fileExtension)
@@ -553,7 +553,7 @@ func (fs *FileSystem) OpenFile(p string, flag int) (filesystem.File, error) {
 		if e.fileExtension != "" {
 			shortName += "." + e.fileExtension
 		}
-		if e.filenameLong != filename && shortName != filename {
+		if !strings.EqualFold(e.filenameLong, filename) && !strings.EqualFold(shortName, filename) {
 			continue
 		}
 		// cannot do anything with directories
@@ -840,7 +840,7 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, []*di
 			// match is determined by any one of:
 			// - long filename == provided name
 			// - uppercase(short filename) == uppercase(provided name)
-			if e.filenameLong != subp && !strings.EqualFold(e.filenameShort, subp) {
+			if !strings.EqualFold(e.filenameLong, subp) && !strings.EqualFold(e.filenameShort, subp) {
 				continue
 			}
 			if !e.isSubdirectory {

--- a/filesystem/fat32/testdata/mkfat32.sh
+++ b/filesystem/fat32/testdata/mkfat32.sh
@@ -28,6 +28,10 @@ mcopy -i /data/fat32.img /CORTO1.TXT ::/
 mcopy -i /data/fat32.img '/Un archivo con nombre largo.dat' ::/
 mcopy -i /data/fat32.img '/tercer_archivo' ::/
 mcopy -i /data/fat32.img '/some_long_embedded_nameא' ::/foo/bar
+mmd -i /data/fat32.img ::/lower83
+mcopy -i /data/fat32.img /CORTO1.TXT ::/lower83/lower.low
+mcopy -i /data/fat32.img /CORTO1.TXT ::/lower83/lower.UPP
+mcopy -i /data/fat32.img /CORTO1.TXT ::/lower83/UPPER.low
 
 i=0
 until [ $i -gt 75 ]; do mmd -i /data/fat32.img ::/foo/dir${i}; i=$(( $i+1 )); done


### PR DESCRIPTION
Let me know if any changes are required.

I wasn't sure if adding another 10MB fat32 image built with mtools was the best way to go for the unit tests but was a little confused when I tried to add it to the existing fat32.img file, it seems that file is not built by the shell script in the same folder.
