### PR TITLE
Speed up fat32 impl

### DIFF
--- a/filesystem/fat32/common_test.go
+++ b/filesystem/fat32/common_test.go
@@ -467,7 +467,7 @@ func testReadFilesystemData() (info *testFSInfo, err error) {
 				rootDirCluster: 2,         // root is at cluster 2
 				size:           sizeInBytes,
 				maxCluster:     numClusters,
-				clusters:       make(map[uint32]uint32),
+				clusters:       make([]uint32, numClusters+1),
 			}
 		case inClusters && len(clusterLineMatch) > 4:
 			start, err := strconv.Atoi(clusterLineMatch[1])

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"sort"
 	"strings"
 	"time"
 
@@ -933,7 +932,6 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 	// 1- calculate how many clusters needed
 	// 2- see how many clusters already are allocated
 	// 3- if needed, allocate new clusters and extend the chain in the FAT table
-	keys := make([]uint32, 0, 20)
 	allocated := make([]uint32, 0, 20)
 
 	// what is the total count of clusters needed?
@@ -965,10 +963,6 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 	// get a list of allocated clusters, so we can know which ones are unallocated and therefore allocatable
 	allClusters := fs.table.clusters
 	maxCluster := fs.table.maxCluster
-	for k := range allClusters {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 
 	if extraClusterCount > 0 {
 		for i := uint32(2); i < maxCluster && len(allocated) < extraClusterCount; i++ {

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -228,17 +228,16 @@ func Create(f util.File, size, start, blocksize int64, volumeLabel string) (*Fil
 	fatSecondaryStart := uint64(fatPrimaryStart) + uint64(fatSize)
 	maxCluster := fatSize / 4
 	rootDirCluster := uint32(2)
+	clusters := make([]uint32, maxCluster+1)
+	clusters[rootDirCluster] = eocMarker
 	fat := table{
 		fatID:          fatID,
 		eocMarker:      eocMarker,
 		unusedMarker:   unusedMarker,
 		size:           fatSize,
 		rootDirCluster: rootDirCluster,
-		clusters: map[uint32]uint32{
-			// when we start, there is just one directory with a single cluster
-			rootDirCluster: eocMarker,
-		},
-		maxCluster: maxCluster,
+		clusters:       clusters,
+		maxCluster:     maxCluster,
 	}
 
 	// where does our data start?
@@ -694,10 +693,9 @@ func (fs *FileSystem) getClusterList(firstCluster uint32) ([]uint32, error) {
 	// first, get the chain of clusters
 	complete := false
 	cluster := firstCluster
-	clusters := fs.table.clusters
 
 	// do we even have a valid cluster?
-	if _, ok := clusters[cluster]; !ok {
+	if cluster > fs.table.maxCluster || fs.table.clusters[cluster] == 0 {
 		return nil, fmt.Errorf("invalid start cluster: %d", cluster)
 	}
 
@@ -706,11 +704,13 @@ func (fs *FileSystem) getClusterList(firstCluster uint32) ([]uint32, error) {
 		// save the current cluster
 		clusterList = append(clusterList, cluster)
 		// get the next cluster
-		newCluster := clusters[cluster]
+		newCluster := fs.table.clusters[cluster]
 		// if it is EOC, we are done
 		switch {
 		case fs.table.isEoc(newCluster):
 			complete = true
+		case newCluster > fs.table.maxCluster:
+			return nil, fmt.Errorf("invalid cluster chain at %d", newCluster)
 		case cluster < 2:
 			return nil, fmt.Errorf("invalid cluster chain at %d", cluster)
 		}
@@ -924,6 +924,10 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, []*di
 // returns the indexes of clusters to be used in order. If the new size is smaller than
 // the original size, will shrink the chain.
 func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, error) {
+	if previous > fs.table.maxCluster {
+		return nil, fmt.Errorf("invalid cluster chain at %d", previous)
+	}
+
 	var (
 		clusters             []uint32
 		err                  error
@@ -961,12 +965,11 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 	}
 
 	// get a list of allocated clusters, so we can know which ones are unallocated and therefore allocatable
-	allClusters := fs.table.clusters
 	maxCluster := fs.table.maxCluster
 
 	if extraClusterCount > 0 {
 		for i := uint32(2); i < maxCluster && len(allocated) < extraClusterCount; i++ {
-			if _, ok := allClusters[i]; !ok {
+			if fs.table.clusters[i] == 0 {
 				// these become the same at this point
 				allocated = append(allocated, i)
 			}
@@ -982,12 +985,12 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 
 		// extend the chain and fill them in
 		if previous > 0 {
-			allClusters[previous] = allocated[0]
+			fs.table.clusters[previous] = allocated[0]
 		}
 		for i := 0; i < lastAlloc; i++ {
-			allClusters[allocated[i]] = allocated[i+1]
+			fs.table.clusters[allocated[i]] = allocated[i+1]
 		}
-		allClusters[allocated[lastAlloc]] = fs.table.eocMarker
+		fs.table.clusters[allocated[lastAlloc]] = fs.table.eocMarker
 
 		// update the FSIS
 		lastAllocatedCluster = allocated[len(allocated)-1]
@@ -1003,13 +1006,21 @@ func (fs *FileSystem) allocateSpace(size uint64, previous uint32) ([]uint32, err
 		}
 		deallocated = clusters[lastAlloc+1:]
 
+		if uint32(lastAlloc) > fs.table.maxCluster || clusters[lastAlloc] > fs.table.maxCluster {
+			return nil, fmt.Errorf("invalid cluster chain at %d", lastAlloc)
+		}
+
 		// mark last allocated one as EOC
-		allClusters[clusters[lastAlloc]] = fs.table.eocMarker
+		fs.table.clusters[clusters[lastAlloc]] = fs.table.eocMarker
 
 		// unmark all of the unused ones
 		lastAllocatedCluster = fs.fsis.lastAllocatedCluster
 		for _, cl := range deallocated {
-			allClusters[cl] = fs.table.unusedMarker
+			if cl > fs.table.maxCluster {
+				return nil, fmt.Errorf("invalid cluster chain at %d", cl)
+			}
+
+			fs.table.clusters[cl] = fs.table.unusedMarker
 			if cl == lastAllocatedCluster {
 				lastAllocatedCluster--
 			}

--- a/filesystem/fat32/table_internal_test.go
+++ b/filesystem/fat32/table_internal_test.go
@@ -3,6 +3,7 @@ package fat32
 import (
 	"bytes"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/diskfs/go-diskfs/util"
@@ -16,13 +17,10 @@ const (
 
 func getValidFat32Table() *table {
 	// make a duplicate, in case someone modifies what we return
-	var t = &table{}
+	t := &table{}
 	*t = *fsInfo.table
 	// and because the clusters are copied by reference
-	t.clusters = make(map[uint32]uint32)
-	for k, v := range fsInfo.table.clusters {
-		t.clusters[k] = v
-	}
+	t.clusters = slices.Clone(t.clusters)
 
 	return t
 }


### PR DESCRIPTION
Hello,

We're looking to use go-diskfs to build an air-gapped installer image for our product. It includes a bunch of files (like grub tree), OCI images, binaries and etc. 

The speed up is 20+ times on bigger file systems - from 540 seconds to 23 seconds for a 1G image with two partitions of ~500MB each.

The test setup is:

```
Intel(R) Core(TM) Ultra 7 155H, 32GiB RAM, SN740 NVMe WD 512GB
go 1.23.0
6.10.7-200.fc40.x86_64 #1 SMP PREEMPT_DYNAMIC
```

Here are three profiling reports:

- Unmodified: [v1.4.1.pdf](https://github.com/user-attachments/files/16949444/v1.4.1.pdf)
- Removing keys sort: [v1.4.1-nosort.pdf](https://github.com/user-attachments/files/16949443/v1.4.1-nosort.pdf)
- Replacing map with slice: [v1.4.1-nomap.pdf](https://github.com/user-attachments/files/16949442/v1.4.1-nomap.pdf)

