### PR TITLE
add more test file creation

### DIFF
--- a/filesystem/fat32/testdata/fat32.go
+++ b/filesystem/fat32/testdata/fat32.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"strconv"
 
 	"github.com/diskfs/go-diskfs"
 	"github.com/diskfs/go-diskfs/disk"
@@ -11,15 +13,37 @@ import (
 
 func main() {
 	filename := "test_file.img"
+	r := rand.New(rand.NewSource(37))
 	os.Remove(filename)
 	fs := mkfs(filename)
+	mkfile(fs, "/testfile")
 	mkdir(fs, "/A")
 	mkdir(fs, "/b")
-	mkfile(fs, "/testfile")
-	mkfile(fs, "/b/sub")
+	for i := 0; i < 100; i++ {
+		inc := strconv.Itoa(i)
+		mkdir(fs, "/b/sub"+inc)
+		mkdir(fs, "/b/sub"+inc+"/blob/")
+		mkfile(fs, "/b/sub"+inc+"/blob/testfile1")
+		mkRandFile(fs, "/b/sub"+inc+"/blob/randFileSize", r.Intn(73))
+		mkSmallFile(fs, "/b/sub"+inc+"/blob/testfile3")
+	}
+	mkGigFile(fs, "/b/sub49/blob/testfile4")
+	mkGigFile(fs, "/b/sub50/blob/testfile4")
+	mkSmallFile(fs, "/b/sub55/blob/testfile4")
+	mkGigFile(fs, "/b/sub55/blob/testfile5")
+	entries, err := fs.ReadDir("/b/sub50/blob")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("/b/sub50/blob/:\n\n", entries)
+	entries, err = fs.ReadDir("/b/sub55/blob")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("/b/sub55/blob/:\n\n", entries)
 }
 func mkfs(name string) filesystem.FileSystem {
-	size := int64(10 * 1024 * 1024)
+	size := int64(6 * 1024 * 1024 * 1024)
 	d, err := diskfs.Create(name, size, diskfs.Raw, diskfs.SectorSizeDefault)
 	if err != nil {
 		fmt.Printf("error creating disk: %v", err)
@@ -45,6 +69,73 @@ func mkfile(fs filesystem.FileSystem, name string) {
 	}
 
 	_, err = rw.Write([]byte("hello World"))
+	if err != nil {
+		panic(err)
+	}
+}
+func mkRandFile(fs filesystem.FileSystem, name string, rSize int) {
+	rw, err := fs.OpenFile(name, os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		panic(err)
+	}
+
+	size := rSize * 1024 * 1024
+	smallFile := make([]byte, size, size)
+	_, err = rw.Write(smallFile)
+	if err != nil {
+		panic(err)
+	}
+}
+func mkSmallFile(fs filesystem.FileSystem, name string) {
+	rw, err := fs.OpenFile(name, os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		panic(err)
+	}
+
+	size := 5 * 1024 * 1024
+	smallFile := make([]byte, size, size)
+	_, err = rw.Write(smallFile)
+	if err != nil {
+		panic(err)
+	}
+}
+func mkMedFile(fs filesystem.FileSystem, name string) {
+	rw, err := fs.OpenFile(name, os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		panic(err)
+	}
+
+	size := 50 * 1024 * 1024
+	medFile := make([]byte, size, size)
+	_, err = rw.Write(medFile)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mkBigFile(fs filesystem.FileSystem, name string) {
+	rw, err := fs.OpenFile(name, os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		panic(err)
+	}
+
+	size := 550 * 1024 * 1024
+	bigFile := make([]byte, size, size)
+	_, err = rw.Write(bigFile)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mkGigFile(fs filesystem.FileSystem, name string) {
+	rw, err := fs.OpenFile(name, os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		panic(err)
+	}
+
+	size := 1024 * 1024 * 1024
+	gigFile := make([]byte, size, size)
+	_, err = rw.Write(gigFile)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I am using this project (its great!) I am seeing an issue when I am creating a bootable disk with two partitions. the first partition is a "normal" efi partition that boots and works well. The second partition is a fat32 filesystem that hold all sorts of files and folders. some of the files are 1 GiB in size. When I am writing to my second partition I see a segfault at the 3rd 1 GiB file. The others seem to do okay. 

This is a PR that will create a tree on a partition and exposes the same error message that I was seeing on my system. The annoying thing is, I _have_ to have the random-sized file creation turned on. to see my issue, so I don't have a simple test case. I saw that you called for a test program in #109 . This is hopefully that program. Happy to discuss further. Again, thank you for this project. 