### PR TITLE
added test for file tree creation with large files

### DIFF
--- a/filesystem/fat32/fat32_test.go
+++ b/filesystem/fat32/fat32_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -1150,8 +1151,9 @@ func mkGigFile(fs filesystem.FileSystem, name string) error {
 }
 func TestCreateFileTree(t *testing.T) {
 	fileName := "file-tree.img"
-	os.Remove(fileName)
-	f, _ := mkfs(fileName)
+	tmpDir := t.TempDir()
+	tmpImgPath := filepath.Join(tmpDir, fileName)
+	f, _ := mkfs(tmpImgPath)
 	err := mkdir(f, "/A")
 	if err != nil {
 		t.Errorf("Error making dir /A in root: %v", err)


### PR DESCRIPTION
This is the PR alluded to in #256. I have added a test case and some supporting functions to trigger an issue I am seeing on my system. `TestCreateFileTree` is the case I am adding. This creates a 6GiB fat32 file system, so hopefully the CI doesn't fall over because of it. 

This is a great project, and you have been very responsive. Thank you. 
```
lblyth@host:~/repos/go-diskfs/filesystem/fat32$ go test                                                             
--- FAIL: TestCreateFileTree (8.11s)                                                                                 
panic: could not read directory entries for /b/sub50/blob [recovered]
        panic: could not read directory entries for /b/sub50/blob
                                                                                                                     
goroutine 263 [running]:                                                                                             
testing.tRunner.func1.2({0x6b7a80, 0xc00002e190})
        /home/lblyth/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
        /home/lblyth/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1635 +0x35e
panic({0x6b7a80?, 0xc00002e190?})                                                                                    
        /home/lblyth/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/runtime/panic.go:785 +0x132
github.com/diskfs/go-diskfs/filesystem/fat32_test.mkGigFile({0x778b38?, 0xc0000f6630?}, {0x70d9bd?, 0x721bcd?})
        /home/lblyth/repos/go-diskfs/filesystem/fat32/fat32_test.go:1134 +0xa5
github.com/diskfs/go-diskfs/filesystem/fat32_test.TestCreateFileTree(0xc0000dc340?)
        /home/lblyth/repos/go-diskfs/filesystem/fat32/fat32_test.go:1162 +0x328
testing.tRunner(0xc0000dc340, 0x7227e0)
        /home/lblyth/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1                                                                           
        /home/lblyth/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1743 +0x390
exit status 2
FAIL    github.com/diskfs/go-diskfs/filesystem/fat32    8.574s  
```