### PR TITLE
Add lazy mode for fat32 to speed up writes

### DIFF
--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -60,6 +60,7 @@ type FileSystem struct {
 	size            int64
 	start           int64
 	file            util.File
+	lazy            bool
 }
 
 // Equal compare if two filesystems are equal
@@ -433,6 +434,10 @@ func (fs *FileSystem) writeBootSector() error {
 }
 
 func (fs *FileSystem) writeFsis() error {
+	if fs.lazy {
+		return nil
+	}
+
 	fsInformationSector := fs.bootSector.biosParameterBlock.fsInformationSector
 	backupBootSector := fs.bootSector.biosParameterBlock.backupBootSector
 	fsisPrimary := int64(fsInformationSector * uint16(SectorSize512))
@@ -453,6 +458,10 @@ func (fs *FileSystem) writeFsis() error {
 }
 
 func (fs *FileSystem) writeFat() error {
+	if fs.lazy {
+		return nil
+	}
+
 	reservedSectors := fs.bootSector.biosParameterBlock.dos331BPB.dos20BPB.reservedSectors
 	fatPrimaryStart := uint64(reservedSectors) * uint64(SectorSize512)
 	fatSecondaryStart := fatPrimaryStart + uint64(fs.table.size)
@@ -683,6 +692,32 @@ func (fs *FileSystem) SetLabel(volumeLabel string) error {
 	err = fs.writeDirectoryEntries(rootDir)
 	if err != nil {
 		return fmt.Errorf("failed to save the root directory to disk: %w", err)
+	}
+
+	return nil
+}
+
+// SetLazy sets the lazy flag for the filesystem. If lazy is true, then the filesystem will not write FAT tables and
+// other metadata to the disk when creating/writing files or directories. After all changes to file system are done
+// Commit() must be called to write the changes to the disk.
+func (fs *FileSystem) SetLazy(lazy bool) {
+	fs.lazy = lazy
+}
+
+// Commit writes the FAT tables and other metadata to the disk. This is only necessary if lazy is set to true.
+func (fs *FileSystem) Commit() error {
+	curr := fs.lazy
+	fs.lazy = false
+	defer func() {
+		fs.lazy = curr
+	}()
+
+	if err := fs.writeFsis(); err != nil {
+		return fmt.Errorf("failed to write the file system information sector: %w", err)
+	}
+
+	if err := fs.writeFat(); err != nil {
+		return fmt.Errorf("failed to write the file allocation table: %w", err)
 	}
 
 	return nil

--- a/filesystem/fat32/fat32_test.go
+++ b/filesystem/fat32/fat32_test.go
@@ -1085,6 +1085,16 @@ func testMkFile(fs filesystem.FileSystem, p string, size int) error {
 }
 
 func TestCreateFileTree(t *testing.T) {
+	testCreateFileTree(t, false)
+}
+
+func TestCreateFileTreeLazy(t *testing.T) {
+	testCreateFileTree(t, true)
+}
+
+func testCreateFileTree(t *testing.T, lazy bool) {
+	t.Helper()
+
 	filename := "fat32_test"
 	tmpDir := t.TempDir()
 	tmpImgPath := filepath.Join(tmpDir, filename)
@@ -1104,6 +1114,7 @@ func TestCreateFileTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating filesystem: %v", err)
 	}
+	fs.(*fat32.FileSystem).SetLazy(lazy)
 
 	if err := fs.Mkdir("/A"); err != nil {
 		t.Errorf("Error making dir /A in root: %v", err)
@@ -1149,5 +1160,9 @@ func TestCreateFileTree(t *testing.T) {
 	file = "/b/sub51/blob/gigfile1"
 	if err := testMkFile(fs, file, gb); err != nil {
 		t.Errorf("Error making gigfile1 %s: %v", file, err)
+	}
+
+	if err := fs.(*fat32.FileSystem).Commit(); err != nil {
+		t.Errorf("Error committing filesystem: %v", err)
 	}
 }


### PR DESCRIPTION
For example, it reduces the time to create ~5GB file system from 7m40s to 1m40s on my laptop.

The main root cause is that currently on every space allocation Fsis/FAT are written and while they're fairly small (like 6-7MB) but it's happening on every "Write" call which is tens of sounds when writing a lot of files.

You can see on the following flame graphs that actual file writes are almost invisible comparing to writing Fsis/FAT.

With v1.4.2:

<img width="1266" alt="Screenshot 2024-09-27 at 8 07 00 PM" src="https://github.com/user-attachments/assets/2889c937-f790-49d1-96e5-58d224df47b5">

Patched, lazy mode enabled:

<img width="1246" alt="Screenshot 2024-09-27 at 8 20 39 PM" src="https://github.com/user-attachments/assets/8115cdc2-3a56-4f91-a083-d6a7ec937022">

I tried to minimize changes to the Public API.
