### PR TITLE
Add docker-in-docker for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,16 @@
 				"Gruntfuggly.todo-tree"
 			]
 		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"azureDnsAutoDetection": false,
+			"installDockerBuildx": false,
+			"installDockerComposeSwitch": false,
+			"version": "latest",
+			"dockerDashComposeVersion": "none"
+		}
 	}
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
As some fat32 tests need docker, devcontainer needs a tweak for that

Followup for https://github.com/diskfs/go-diskfs/pull/266