### PR TITLE
fix: xattr table index to split position into decompressed and compressed offset

### DIFF
--- a/filesystem/squashfs/const_internal_test.go
+++ b/filesystem/squashfs/const_internal_test.go
@@ -199,12 +199,12 @@ func testGetFilesystem(f fs.File) (*FileSystem, []byte, error) {
 	return testFs, b, nil
 }
 
-func testGetInodeMetabytes() (inodeBytes []byte, inodesStart uint64, err error) {
+func testGetInodeMetabytes() (inodeBytes []byte, err error) {
 	testFs, b, err := testGetFilesystem(nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return b[testFs.superblock.inodeTableStart+2:], testFs.superblock.inodeTableStart, nil
+	return b[testFs.superblock.inodeTableStart+2:], nil
 }
 
 //nolint:deadcode // we need these references in the future

--- a/filesystem/squashfs/inode_internal_test.go
+++ b/filesystem/squashfs/inode_internal_test.go
@@ -69,7 +69,7 @@ func TestInodeSize(t *testing.T) {
 }
 
 func TestInodeHeader(t *testing.T) {
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestBlockData(t *testing.T) {
 
 func TestBasicDirectory(t *testing.T) {
 	dir := testBasicDirectory
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestExtendedDirectory(t *testing.T) {
 
 func TestBasicFile(t *testing.T) {
 	f := testBasicFile
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestBasicFile(t *testing.T) {
 func TestExtendedFile(t *testing.T) {
 	fd := testExtendedFile
 	f := &fd
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestExtendedFile(t *testing.T) {
 
 func TestBasicSymlink(t *testing.T) {
 	s := testBasicSymlink
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +430,7 @@ func TestExtendedIPC(t *testing.T) {
 }
 
 func TestInode(t *testing.T) {
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filesystem/squashfs/squashfs_internal_test.go
+++ b/filesystem/squashfs/squashfs_internal_test.go
@@ -68,7 +68,7 @@ func TestValidateBlocksize(t *testing.T) {
 
 func TestParseXAttrsTable(t *testing.T) {
 	// parseXattrsTable(bUIDXattr, bIndex []byte, offset uint64, c compressor) (*xAttrTable, error) {
-	b, _, err := testGetInodeMetabytes()
+	b, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatalf("error getting metadata bytes: %v", err)
 	}

--- a/filesystem/squashfs/squashfs_internal_test.go
+++ b/filesystem/squashfs/squashfs_internal_test.go
@@ -68,7 +68,7 @@ func TestValidateBlocksize(t *testing.T) {
 
 func TestParseXAttrsTable(t *testing.T) {
 	// parseXattrsTable(bUIDXattr, bIndex []byte, offset uint64, c compressor) (*xAttrTable, error) {
-	b, offset, err := testGetInodeMetabytes()
+	b, _, err := testGetInodeMetabytes()
 	if err != nil {
 		t.Fatalf("error getting metadata bytes: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestParseXAttrsTable(t *testing.T) {
 
 	// entries in the xattr ID table are offset from beginning of disk, not from xattr table
 	//   so need offset of bUIDXattr from beginning of disk to make use of it
-	table, err := parseXattrsTable(bUIDXattr, bIndex, offset+startUID, nil)
+	table, err := parseXattrsTable(bUIDXattr, bIndex, map[uint32]uint32{0: 0}, nil)
 	if err != nil {
 		t.Fatalf("error reading xattrs table: %v", err)
 	}

--- a/filesystem/squashfs/xattr.go
+++ b/filesystem/squashfs/xattr.go
@@ -18,15 +18,23 @@ type xAttrIndex struct {
 	size  uint32
 }
 
-func parseXAttrIndex(b []byte) (*xAttrIndex, error) {
+func parseXAttrIndex(b []byte, offsetMap map[uint32]uint32) (*xAttrIndex, error) {
 	if len(b) < int(xAttrIDEntrySize) {
 		return nil, fmt.Errorf("cannot parse xAttr Index of size %d less than minimum %d", len(b), xAttrIDEntrySize)
 	}
-	return &xAttrIndex{
-		pos:   binary.LittleEndian.Uint64(b[0:8]),
+
+	offsetKey := binary.LittleEndian.Uint32(b[2:6])
+	offset, ok := offsetMap[offsetKey]
+	if !ok {
+		return nil, fmt.Errorf("cannot parse xAttr Index invalid offset key %d", offsetKey)
+	}
+	toReturn := &xAttrIndex{
+		pos:   uint64(binary.LittleEndian.Uint16(b[0:2])) + uint64(offset),
 		count: binary.LittleEndian.Uint32(b[8:12]),
 		size:  binary.LittleEndian.Uint32(b[12:16]),
-	}, nil
+	}
+
+	return toReturn, nil
 }
 
 type xAttrTable struct {
@@ -39,6 +47,9 @@ func (x *xAttrTable) find(pos int) (map[string]string, error) {
 		return nil, fmt.Errorf("position %d is greater than list size %d", pos, len(x.list))
 	}
 	entry := x.list[pos]
+	if int(entry.pos) >= len(x.data) {
+		return nil, fmt.Errorf("entry position %d is greater than list size %d", entry.pos, len(x.data))
+	}
 	b := x.data[entry.pos:]
 	count := entry.count
 	ptr := 0


### PR DESCRIPTION
fixes: diskfs/go-diskfs/issues/276