### PR TITLE
fix: dont include xattr in extended link reading

### DIFF
--- a/filesystem/squashfs/inode.go
+++ b/filesystem/squashfs/inode.go
@@ -639,11 +639,12 @@ func parseExtendedSymlink(b []byte) (*extendedSymlink, int, error) {
 	s := &extendedSymlink{
 		links: binary.LittleEndian.Uint32(b[0:4]),
 	}
+	targetSize := int(binary.LittleEndian.Uint32(b[4:8]))
 	// account for the synlink target, plus 4 bytes for the xattr index after it
-	extra = int(binary.LittleEndian.Uint32(b[4:8])) + 4
-	if len(b[target:]) > extra {
-		s.target = string(b[8 : 8+extra])
-		s.xAttrIndex = binary.LittleEndian.Uint32(b[8+extra : 8+extra+4])
+	extra = targetSize + 4
+	if len(b) > extra+target {
+		s.target = string(b[target : target+targetSize])
+		s.xAttrIndex = binary.LittleEndian.Uint32(b[target+targetSize : target+targetSize+4])
 		extra = 0
 	}
 	return s, extra, nil

--- a/filesystem/squashfs/inode.go
+++ b/filesystem/squashfs/inode.go
@@ -642,7 +642,7 @@ func parseExtendedSymlink(b []byte) (*extendedSymlink, int, error) {
 	targetSize := int(binary.LittleEndian.Uint32(b[4:8]))
 	// account for the synlink target, plus 4 bytes for the xattr index after it
 	extra = targetSize + 4
-	if len(b) > extra+target {
+	if len(b) >= extra+target {
 		s.target = string(b[target : target+targetSize])
 		s.xAttrIndex = binary.LittleEndian.Uint32(b[target+targetSize : target+targetSize+4])
 		extra = 0

--- a/filesystem/squashfs/squashfs.go
+++ b/filesystem/squashfs/squashfs.go
@@ -532,7 +532,7 @@ func (fs *FileSystem) hydrateDirectoryEntries(entries []*directoryEntryRaw) ([]*
 		body, header := in.getBody(), in.getHeader()
 		xattrIndex, has := body.xattrIndex()
 		xattrs := map[string]string{}
-		if has && xattrIndex != noXattrInodeFlag {
+		if has {
 			xattrs, err = fs.xattrs.find(int(xattrIndex))
 			if err != nil {
 				return nil, fmt.Errorf("error reading xattrs for %s: %v", e.name, err)


### PR DESCRIPTION
Got an error when trying to read another squashfs file from ubuntu. Not sure if I should have created an issue first. It was raising [this](https://github.com/diskfs/go-diskfs/blob/master/filesystem/squashfs/xattr.go#L23) error. Traced it down to a symlink reading the wrong part for the xattr.