### PR TITLE
Fix panic when tmp path is inccurate

### DIFF
--- a/filesystem/iso9660/finalize_test.go
+++ b/filesystem/iso9660/finalize_test.go
@@ -23,6 +23,23 @@ var (
 
 // test creating an iso with el torito boot
 func TestFinalizeElTorito(t *testing.T) {
+	finalizeElTorito(t, "")
+	dir, err := os.MkdirTemp("", "workspace")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	finalizeElTorito(t, dir)
+}
+func TestFinalizeElToritoWithInaccurateTmpDir(t *testing.T) {
+	finalizeElTorito(t, "")
+	dir, err := os.MkdirTemp("/tmp//", "workspace")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	finalizeElTorito(t, dir)
+}
+
+func finalizeElTorito(t *testing.T, workspace string) {
 	blocksize := int64(2048)
 	f, err := os.CreateTemp("", "iso_finalize_test")
 	defer os.Remove(f.Name())
@@ -31,7 +48,7 @@ func TestFinalizeElTorito(t *testing.T) {
 	}
 
 	b := file.New(f, false)
-	fs, err := iso9660.Create(b, 0, 0, blocksize, "")
+	fs, err := iso9660.Create(b, 0, 0, blocksize, workspace)
 	if err != nil {
 		t.Fatalf("Failed to iso9660.Create: %v", err)
 	}

--- a/filesystem/iso9660/finalize_test.go
+++ b/filesystem/iso9660/finalize_test.go
@@ -30,6 +30,7 @@ func TestFinalizeElTorito(t *testing.T) {
 	}
 	finalizeElTorito(t, dir)
 }
+
 func TestFinalizeElToritoWithInaccurateTmpDir(t *testing.T) {
 	finalizeElTorito(t, "")
 	dir, err := os.MkdirTemp("/tmp//", "workspace")
@@ -39,6 +40,7 @@ func TestFinalizeElToritoWithInaccurateTmpDir(t *testing.T) {
 	finalizeElTorito(t, dir)
 }
 
+//nolint:thelper // this is not a helper function
 func finalizeElTorito(t *testing.T, workspace string) {
 	blocksize := int64(2048)
 	f, err := os.CreateTemp("", "iso_finalize_test")

--- a/filesystem/iso9660/iso9660.go
+++ b/filesystem/iso9660/iso9660.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/diskfs/go-diskfs/backend"
 	"github.com/diskfs/go-diskfs/filesystem"
@@ -96,6 +97,9 @@ func Create(b backend.Storage, size, start, blocksize int64, workspace string) (
 			return nil, fmt.Errorf("could not create working directory: %v", err)
 		}
 	}
+
+	// sometimes, at least on macos, extra separators in path can cause panic
+	workdir = filepath.Clean(workdir)
 
 	// create root directory
 	// there is nothing in there


### PR DESCRIPTION
prior this fix if TMPDIR is set to something like `/tmp//` the iso9660 creation would cause panic.


now it's fixed + test case is added according to @dietch review