### PR TITLE
squashfs: fix directory inode size

### DIFF
--- a/filesystem/squashfs/finalize.go
+++ b/filesystem/squashfs/finalize.go
@@ -1448,7 +1448,7 @@ func populateDirectoryLocations(directories []*finalizeFileInfo) {
 		d.directoryLocation = blockPosition{
 			block:  uint32(pos / int(metadataBlockSize)),
 			offset: uint16(pos % int(metadataBlockSize)),
-			size:   len(b),
+			size:   len(b) + 3,
 		}
 		pos += len(b)
 	}


### PR DESCRIPTION
Due to SquashFS spec
https://dr-emann.github.io/squashfs/squashfs.html#_directory_inodes Section 5.2, it says about directory inode file size

'''
	This value is 3 bytes larger than the real listing. The Linux
kernel creates "." and ".." entries for offsets 0 and 1, and only after 3 looks into the listing, subtracting 3 from the size. '''

In go-disks the size is calculated by serialize the 'directory'. A directory serialization includes multiple 'directoryHeader's and 'directoryEntryRaw's. This aligns with the dir_size calculation logic with well-known squasjfs-tools project

https://github.com/plougher/squashfs-tools/blob/master/squashfs-tools/mksquashfs.c#L1549

Note that the file_size is set to 3 larger than the size.

Thus here, we set directoryLocation.size to 3 bytes larger and the new value will be used to set basicDirectory.fileSize.

Fixes #285