### PR TITLE
Support ISO version 2 reading

### DIFF
--- a/filesystem/iso9660/iso9660.go
+++ b/filesystem/iso9660/iso9660.go
@@ -160,7 +160,7 @@ func Read(b backend.Storage, size, start, blocksize int64) (*FileSystem, error) 
 	// we do not do anything with the system area for now
 
 	// next read the volume descriptors, one at a time, until we hit the terminator
-	vds := make([]volumeDescriptor, 2)
+	vds := make([]volumeDescriptor, 0, 128)
 	terminated := false
 	var (
 		pvd *primaryVolumeDescriptor

--- a/filesystem/iso9660/volume_descriptor.go
+++ b/filesystem/iso9660/volume_descriptor.go
@@ -183,8 +183,8 @@ func volumeDescriptorFromBytes(b []byte) (volumeDescriptor, error) {
 	}
 	// validate the version
 	version := b[6]
-	if version != isoVersion {
-		return nil, fmt.Errorf("mismatched ISO version in Volume Descriptor. Found %x expected %x", version, isoVersion)
+	if volumeDescriptorType(b[0]) == volumeDescriptorPrimary && version != isoVersion {
+		return nil, fmt.Errorf("mismatched ISO version in Primary Volume Descriptor. Found %x expected %x", version, isoVersion)
 	}
 	// get the type and data - later we will be more intelligent about this and read actual primary volume info
 	vdType := volumeDescriptorType(b[0])


### PR DESCRIPTION
SVDs may have version greater than 1. For now let's check PVD version only.
    
closes https://github.com/diskfs/go-diskfs/issues/290