### PR TITLE
Add initial support for Fat12 and Fat16 filesystems

### DIFF
--- a/filesystem/fat32/dos71bpb.go
+++ b/filesystem/fat32/dos71bpb.go
@@ -92,36 +92,50 @@ func dos71EBPBFromBytes(b []byte) (*dos71EBPB, int, error) {
 	}
 	bpb.dos331BPB = dos331bpb
 
-	bpb.sectorsPerFat = binary.LittleEndian.Uint32(b[25:29])
-	bpb.mirrorFlags = binary.LittleEndian.Uint16(b[29:31])
-	version := binary.LittleEndian.Uint16(b[31:33])
-	if version != uint16(fatVersion0) {
-		return nil, size, fmt.Errorf("invalid FAT32 version found: %v", version)
+	// Always 0 on FAT32 volumes
+	// http://elm-chan.org/docs/fat_e.html#bpb
+	if dos331bpb.dos20BPB.sectorsPerFat == 0 {
+		bpb.sectorsPerFat = binary.LittleEndian.Uint32(b[25:29])
 	}
-	bpb.version = fatVersion0
-	bpb.rootDirectoryCluster = binary.LittleEndian.Uint32(b[33:37])
-	bpb.fsInformationSector = binary.LittleEndian.Uint16(b[37:39])
-	bpb.backupBootSector = binary.LittleEndian.Uint16(b[39:41])
-	bootFileName := b[41:53]
-	copy(bpb.bootFileName[:], bootFileName)
-	bpb.driveNumber = b[53]
-	bpb.reservedFlags = b[54]
-	extendedSignature := b[55]
-	bpb.extendedBootSignature = extendedSignature
-	// is this a longer or shorter one
-	bpb.volumeSerialNumber = binary.BigEndian.Uint32(b[56:60])
 
-	switch extendedSignature {
+	// If FAT32 read the following fields from different places
+	if dos331bpb.FatType() == 32 {
+		bpb.mirrorFlags = binary.LittleEndian.Uint16(b[29:31])
+		version := binary.LittleEndian.Uint16(b[31:33])
+		if version != uint16(fatVersion0) {
+			return nil, size, fmt.Errorf("invalid FAT32 version found: %v", version)
+		}
+		bpb.version = fatVersion0
+		bpb.rootDirectoryCluster = binary.LittleEndian.Uint32(b[33:37])
+		bpb.fsInformationSector = binary.LittleEndian.Uint16(b[37:39])
+		bpb.backupBootSector = binary.LittleEndian.Uint16(b[39:41])
+		bootFileName := b[41:53]
+		copy(bpb.bootFileName[:], bootFileName)
+		bpb.driveNumber = b[53]
+		bpb.reservedFlags = b[54]
+		extendedSignature := b[55]
+		bpb.extendedBootSignature = extendedSignature
+		// is this a longer or shorter one
+		bpb.volumeSerialNumber = binary.BigEndian.Uint32(b[56:60])
+	} else {
+		bpb.driveNumber = b[25]
+		bpb.reservedFlags = b[26]
+		bpb.extendedBootSignature = b[27]
+		bpb.volumeSerialNumber = binary.BigEndian.Uint32(b[28:32])
+	}
+
+	re := regexp.MustCompile(" +$")
+	switch bpb.extendedBootSignature {
 	case shortDos71EBPB:
 		size = 60
+		bpb.volumeLabel = re.ReplaceAllString(string(b[32:43]), "")
+		bpb.fileSystemType = re.ReplaceAllString(string(b[43:51]), "")
 	case longDos71EBPB:
 		size = 79
-		// remove padding from each
-		re := regexp.MustCompile(" +$")
 		bpb.volumeLabel = re.ReplaceAllString(string(b[60:71]), "")
 		bpb.fileSystemType = re.ReplaceAllString(string(b[71:79]), "")
 	default:
-		return nil, size, fmt.Errorf("unknown DOS 7.1 EBPB Signature: %v", extendedSignature)
+		return nil, size, fmt.Errorf("unknown DOS 7.1 EBPB Signature: %v", bpb.extendedBootSignature)
 	}
 
 	return &bpb, size, nil

--- a/filesystem/fat32/fat32_internal_test.go
+++ b/filesystem/fat32/fat32_internal_test.go
@@ -77,7 +77,7 @@ func getValidFat32FSSmall() *FileSystem {
 				return len(b), nil
 			},
 		}, false),
-		fsis: FSInformationSector{},
+		fsis: &FSInformationSector{},
 		bootSector: msDosBootSector{
 			biosParameterBlock: &dos71EBPB{
 				fsInformationSector: 2,

--- a/filesystem/fat32/table.go
+++ b/filesystem/fat32/table.go
@@ -31,12 +31,22 @@ func (t *table) equal(a *table) bool {
 		slices.Equal(a.clusters, t.clusters)
 }
 
-/*
-  when reading from disk, remember that *any* of the following is a valid eocMarker:
-  0x?ffffff8 - 0x?fffffff
-*/
+func tableFromBytes(b []byte, fatType int) *table {
+	switch fatType {
+	case 12:
+		return tableFromBytes12(b)
+	case 16:
+		return tableFromBytes16(b)
+	default:
+		return tableFromBytes32(b)
+	}
+}
 
-func tableFromBytes(b []byte) *table {
+/*
+when reading from disk, remember that *any* of the following is a valid eocMarker:
+0x?ffffff8 - 0x?fffffff
+*/
+func tableFromBytes32(b []byte) *table {
 	maxCluster := uint32(len(b) / 4)
 
 	t := table{
@@ -60,8 +70,87 @@ func tableFromBytes(b []byte) *table {
 	return &t
 }
 
+func tableFromBytes16(b []byte) *table {
+	maxCluster := uint32(len(b) / 2)
+
+	t := table{
+		fatID:          uint32(binary.LittleEndian.Uint16(b[0:2])),
+		eocMarker:      uint32(binary.LittleEndian.Uint16(b[2:4])),
+		size:           uint32(len(b)),
+		clusters:       make([]uint32, maxCluster+1),
+		maxCluster:     maxCluster,
+		rootDirCluster: 2,
+	}
+
+	// Parse clusters starting from 2
+	for i := uint32(2); i < t.maxCluster; i++ {
+		bStart := i * 2
+		bEnd := bStart + 2
+		val := uint32(binary.LittleEndian.Uint16(b[bStart:bEnd]))
+
+		// 0 indicates an empty cluster, so we can ignore
+		if val != 0 {
+			t.clusters[i] = val
+		}
+	}
+	return &t
+}
+
+func tableFromBytes12(b []byte) *table {
+	maxCluster := uint32(len(b) * 2 / 3) // 1.5 bytes (12 bits) per entry
+
+	t := table{
+		fatID:          uint32(getFAT12Entry(b, 0)),
+		eocMarker:      uint32(getFAT12Entry(b, 1)),
+		size:           uint32(len(b)),
+		clusters:       make([]uint32, maxCluster+1),
+		maxCluster:     maxCluster,
+		rootDirCluster: 2,
+	}
+
+	// Parse clusters starting from 2
+	for i := uint32(2); i < t.maxCluster; i++ {
+		val := uint32(getFAT12Entry(b, i))
+
+		// 0 indicates an empty cluster, so we can ignore
+		if val != 0 {
+			t.clusters[i] = val
+		}
+	}
+	return &t
+}
+
+func getFAT12Entry(b []byte, cluster uint32) uint16 {
+	bytePos := (cluster * 3) / 2
+
+	if cluster%2 == 0 {
+		// even cluster numbers take 12 bits: 8 from first byte and 4 from second byte
+		if bytePos+1 >= uint32(len(b)) {
+			return 0
+		}
+		return uint16(b[bytePos]) | ((uint16(b[bytePos+1]) & 0x0F) << 8)
+	} else {
+		// odd cluster numbers take 12 bits: 4 from first byte and 8 from second byte
+		if bytePos+1 >= uint32(len(b)) {
+			return 0
+		}
+		return uint16(b[bytePos]>>4) | (uint16(b[bytePos+1]) << 4)
+	}
+}
+
 // bytes returns a FAT32 table as bytes ready to be written to disk
-func (t *table) bytes() []byte {
+func (t *table) bytes(fatType int) []byte {
+	switch fatType {
+	case 12:
+		return t.bytes12()
+	case 16:
+		return t.bytes16()
+	default:
+		return t.bytes32()
+	}
+}
+
+func (t *table) bytes32() []byte {
 	b := make([]byte, t.size)
 
 	// FAT ID and fixed values
@@ -80,6 +169,69 @@ func (t *table) bytes() []byte {
 	return b
 }
 
-func (t *table) isEoc(cluster uint32) bool {
-	return cluster&0xFFFFFF8 == 0xFFFFFF8
+func (t *table) bytes16() []byte {
+	b := make([]byte, t.size)
+
+	// FAT ID and fixed values
+	binary.LittleEndian.PutUint16(b[0:2], uint16(t.fatID))
+	// End-of-Cluster marker
+	binary.LittleEndian.PutUint16(b[2:4], uint16(t.eocMarker))
+	// now just clusters
+	numClusters := t.maxCluster
+	for i := uint32(2); i < numClusters; i++ {
+		bStart := i * 2
+		bEnd := bStart + 2
+		val := t.clusters[i]
+		binary.LittleEndian.PutUint16(b[bStart:bEnd], uint16(val))
+	}
+
+	return b
+}
+
+func (t *table) bytes12() []byte {
+	b := make([]byte, t.size)
+
+	// Write FAT ID and EOC marker using helper function
+	setFat12Entry(b, 0, uint16(t.fatID))
+	setFat12Entry(b, 1, uint16(t.eocMarker))
+
+	// now just clusters
+	numClusters := t.maxCluster
+	for i := uint32(2); i < numClusters; i++ {
+		setFat12Entry(b, i, uint16(t.clusters[i]))
+	}
+
+	return b
+}
+
+func setFat12Entry(b []byte, cluster uint32, value uint16) {
+	bytePos := (cluster * 3) / 2
+
+	if cluster%2 == 0 {
+		// Even cluster numbers: 8 bits to first byte and 4 bits to second byte
+		if bytePos+1 >= uint32(len(b)) {
+			return
+		}
+		b[bytePos] = byte(value & 0xFF)
+		b[bytePos+1] = (b[bytePos+1] & 0xF0) | byte((value>>8)&0x0F)
+	} else {
+		// Odd cluster numbers: 4 bits to first byte and 8 bits to second byte
+		if bytePos+1 >= uint32(len(b)) {
+			return
+		}
+		b[bytePos] = (b[bytePos] & 0x0F) | byte((value&0x0F)<<4)
+		b[bytePos+1] = byte(value >> 4)
+	}
+}
+
+// http://elm-chan.org/docs/fat_e.html#file_cluster
+func (t *table) isEoc(cluster uint32, fatType int) bool {
+	switch fatType {
+	case 12:
+		return cluster&0xFF8 == 0xFF8
+	case 16:
+		return cluster&0xFFF8 == 0xFFF8
+	default:
+		return cluster&0xFFFFFF8 == 0xFFFFFF8
+	}
 }

--- a/filesystem/fat32/table_internal_test.go
+++ b/filesystem/fat32/table_internal_test.go
@@ -32,7 +32,7 @@ func TestFat32TableFromBytes(t *testing.T) {
 			t.Fatalf("error reading test fixture data from %s: %v", Fat32File, err)
 		}
 		b := input[fsInfo.firstFAT : fsInfo.firstFAT+fsInfo.sectorsPerFAT*fsInfo.bytesPerSector]
-		result := tableFromBytes(b)
+		result := tableFromBytes(b, 32)
 		if result == nil {
 			t.Fatalf("returned FAT32 Table was nil unexpectedly")
 		}
@@ -48,7 +48,7 @@ func TestFat32TableFromBytes(t *testing.T) {
 func TestFat32TableToBytes(t *testing.T) {
 	t.Run("valid FAT32 table", func(t *testing.T) {
 		table := getValidFat32Table()
-		b := table.bytes()
+		b := table.bytes(32)
 		if b == nil {
 			t.Fatal("b was nil unexpectedly")
 		}
@@ -85,7 +85,7 @@ func TestFat32TableIsEoc(t *testing.T) {
 	}
 	tab := table{}
 	for _, tt := range tests {
-		eoc := tab.isEoc(tt.cluster)
+		eoc := tab.isEoc(tt.cluster, 32)
 		if eoc != tt.eoc {
 			t.Errorf("isEoc(%x): actual %t instead of expected %t", tt.cluster, eoc, tt.eoc)
 		}


### PR DESCRIPTION
This is most definitely a draft right now, but seeking some early feedback.
For the filesystems I'm dealing with, this was able to read a FAT16 volume and list its root directory.

I did re-use the `fat32` package though, since so much of its code can be re-used.
The implementation here is far from complete (would need tests, and handling other cases as necessary).

Main question before I go any further with this: Should this sit within the `fat32` package, or should we split up the `fat32` package into other packages? Do you have any other suggestions?