### PR TITLE
feat(fat32): Add file system attribute setting and checking functions

### DIFF
--- a/filesystem/fat32/directoryentry.go
+++ b/filesystem/fat32/directoryentry.go
@@ -64,6 +64,21 @@ func (de *directoryEntry) toBytes() ([]byte, error) {
 	createDate, createTime := timeToDateTime(de.createTime)
 	modifyDate, modifyTime := timeToDateTime(de.modifyTime)
 	accessDate, _ := timeToDateTime(de.accessTime)
+	if de.isSystem {
+		dosBytes[11] |= 0x04
+	} else {
+		dosBytes[11] &= ^byte(0x04)
+	}
+	if de.isHidden {
+		dosBytes[11] |= 0x02
+	} else {
+		dosBytes[11] &= ^byte(0x02)
+	}
+	if de.isReadOnly {
+		dosBytes[11] |= 0x01
+	} else {
+		dosBytes[11] &= ^byte(0x01)
+	}
 	binary.LittleEndian.PutUint16(dosBytes[14:16], createTime)
 	binary.LittleEndian.PutUint16(dosBytes[16:18], createDate)
 	binary.LittleEndian.PutUint16(dosBytes[18:20], accessDate)
@@ -146,6 +161,9 @@ byteLoop:
 			lfn = tmpLfn + lfn
 			continue
 		}
+		isSystem := b[i+11]&0x04 == 0x04
+		isHidden := b[i+11]&0x02 == 0x02
+		isReadOnly := b[i+11]&0x01 == 0x01
 		// not LFN, so parse regularly
 		createTime := binary.LittleEndian.Uint16(b[i+14 : i+16])
 		createDate := binary.LittleEndian.Uint16(b[i+16 : i+18])
@@ -176,6 +194,9 @@ byteLoop:
 			isVolumeLabel:      isVolumeLabel,
 			lowercaseShortname: lowercaseShortname,
 			lowercaseExtension: lowercaseExtension,
+			isReadOnly:         isReadOnly,
+			isHidden:           isHidden,
+			isSystem:           isSystem,
 		}
 		lfn = ""
 		dirEntries = append(dirEntries, &entry)

--- a/filesystem/fat32/file.go
+++ b/filesystem/fat32/file.go
@@ -279,7 +279,7 @@ func (fl *File) SetSystem(on bool) error {
 	return fs.writeDirectoryEntries(fl.parent)
 }
 
-func (fl *File) IsSystem(on bool) bool {
+func (fl *File) IsSystem() bool {
 	return fl.isSystem
 }
 
@@ -289,7 +289,7 @@ func (fl *File) SetHidden(on bool) error {
 	return fs.writeDirectoryEntries(fl.parent)
 }
 
-func (fl *File) IsHidden(on bool) bool {
+func (fl *File) IsHidden() bool {
 	return fl.isHidden
 }
 
@@ -299,6 +299,6 @@ func (fl *File) SetReadOnly(on bool) error {
 	return fs.writeDirectoryEntries(fl.parent)
 }
 
-func (fl *File) IsReadOnly(on bool) bool {
+func (fl *File) IsReadOnly() bool {
 	return fl.isReadOnly
 }

--- a/filesystem/fat32/file.go
+++ b/filesystem/fat32/file.go
@@ -272,3 +272,33 @@ func (fl *File) Close() error {
 	fl.filesystem = nil
 	return nil
 }
+
+func (fl *File) SetSystem(on bool) error {
+	fs := fl.filesystem
+	fl.isSystem = on
+	return fs.writeDirectoryEntries(fl.parent)
+}
+
+func (fl *File) IsSystem(on bool) bool {
+	return fl.isSystem
+}
+
+func (fl *File) SetHidden(on bool) error {
+	fs := fl.filesystem
+	fl.isHidden = on
+	return fs.writeDirectoryEntries(fl.parent)
+}
+
+func (fl *File) IsHidden(on bool) bool {
+	return fl.isHidden
+}
+
+func (fl *File) SetReadOnly(on bool) error {
+	fs := fl.filesystem
+	fl.isReadOnly = on
+	return fs.writeDirectoryEntries(fl.parent)
+}
+
+func (fl *File) IsReadOnly(on bool) bool {
+	return fl.isReadOnly
+}


### PR DESCRIPTION
Added the ability to set and check file attributes for the FAT32 file system, including system files, hidden files, and read-only files. These attributes are correctly encoded and decoded in directory entries to ensure persistence and consistency of file attributes.