### PR TITLE
Add LZO decompressor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 *.so
 *.dylib
 
+# IDE specific files
+.idea/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/filesystem/squashfs/compressor.go
+++ b/filesystem/squashfs/compressor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/anchore/go-lzo"
 	"github.com/klauspost/compress/zstd"
 	lz4 "github.com/pierrec/lz4/v4"
 	"github.com/ulikunitz/xz"
@@ -359,6 +360,34 @@ func (c *CompressorZstd) decompress(in []byte) ([]byte, error) {
 	return p, nil
 }
 
+type CompressorLzo struct {
+}
+
+func (c *CompressorLzo) compress(_ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("LZO compression not yet supported")
+}
+func (c *CompressorLzo) decompress(in []byte) ([]byte, error) {
+	b := bytes.NewReader(in)
+	lz := lzo.NewReader(b)
+	p, err := io.ReadAll(lz)
+	if err != nil {
+		return nil, fmt.Errorf("error decompressing: %v", err)
+	}
+	return p, nil
+}
+
+//nolint:unused,revive // it is important to implement the interface
+func (c *CompressorLzo) loadOptions(b []byte) error {
+	// lzo has no supported options
+	return nil
+}
+func (c *CompressorLzo) optionsBytes() []byte {
+	return []byte{}
+}
+func (c *CompressorLzo) flavour() compression {
+	return compressionLzo
+}
+
 func newCompressor(flavour compression) (Compressor, error) {
 	var c Compressor
 	switch flavour {
@@ -369,7 +398,7 @@ func newCompressor(flavour compression) (Compressor, error) {
 	case compressionLzma:
 		c = &CompressorLzma{}
 	case compressionLzo:
-		return nil, fmt.Errorf("LZO compression not yet supported")
+		c = &CompressorLzo{}
 	case compressionXz:
 		c = &CompressorXz{}
 	case compressionLz4:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/diskfs/go-diskfs
 
-go 1.22
+go 1.24.0
 
 require (
+	github.com/anchore/go-lzo v0.1.0
 	github.com/djherbis/times v1.6.0
 	github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab
 	github.com/go-test/deep v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/anchore/go-lzo v0.1.0 h1:NgAacnzqPeGH49Ky19QKLBZEuFRqtTG9cdaucc3Vncs=
+github.com/anchore/go-lzo v0.1.0/go.mod h1:3kLx0bve2oN1iDwgM1U5zGku1Tfbdb0No5qp1eL1fIk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This adds support for LZO decompression (not compression) capabilities for squashfs filesystems. The underlying library is MIT licensed and supports LZO1X only (which is fairly common).