### PR TITLE
fix: handle caching sparse reading block

### DIFF
--- a/filesystem/squashfs/const_internal_test.go
+++ b/filesystem/squashfs/const_internal_test.go
@@ -288,3 +288,33 @@ func GetTestFileBig(f fs.File, c Compressor) (*File, error) {
 		filesystem:   testFs,
 	}, nil
 }
+
+// GetTestSparseFile get a *squashfs.File to a usable and known test file
+func GetTestSparseFile(f fs.File, c Compressor) (*File, error) {
+	testFs, _, err := testGetFilesystem(f)
+	if err != nil {
+		return nil, err
+	}
+	testFs.compressor = c
+	ef := &extendedFile{
+		blocksStart:        superblockSize,
+		fileSize:           uint64(7 + testFs.blocksize),
+		sparse:             uint64(testFs.blocksize),
+		links:              0,
+		fragmentBlockIndex: 0,
+		fragmentOffset:     0,
+		xAttrIndex:         0,
+		blockSizes: []*blockData{
+			{size: 0, compressed: false}, // sparse block
+			{size: 7, compressed: false},
+		},
+	}
+	// inode 0, offset 0, name "README.md", type basic file
+	return &File{
+		extendedFile: ef,
+		isReadWrite:  false,
+		isAppend:     false,
+		offset:       0,
+		filesystem:   testFs,
+	}, nil
+}

--- a/filesystem/squashfs/file_test.go
+++ b/filesystem/squashfs/file_test.go
@@ -69,7 +69,7 @@ func TestFileRead(t *testing.T) {
 		// stub the file reader
 		f, err := squashfs.GetTestFileBig(fileImpl, nil)
 		if err != nil {
-			t.Fatalf("unable to get small test file: %v", err)
+			t.Fatalf("unable to get big test file: %v", err)
 		}
 
 		filesize := blocksize + 5
@@ -84,6 +84,27 @@ func TestFileRead(t *testing.T) {
 		bString := string(b[:read])
 		if !bytes.Equal(b[:read], contentLong) {
 			t.Errorf("Mismatched content:\nActual: '%s...'\nExpected: '%s...'", bString[:20], contentLong[:20])
+		}
+	})
+	t.Run("sparse blocks", func(t *testing.T) {
+		// stub the file reader
+		f, err := squashfs.GetTestSparseFile(fileImpl, nil)
+		if err != nil {
+			t.Fatalf("unable to get sparse test file: %v", err)
+		}
+		contentSparse := append(make([]byte, blocksize), contentLong[:7]...)
+
+		filesize := blocksize + 7
+		b := make([]byte, filesize)
+		read, err := f.Read(b)
+		if err != nil && err != io.EOF {
+			t.Errorf("received unexpected error when reading: %v", err)
+		}
+		if read != len(contentSparse) {
+			t.Errorf("read %d bytes instead of expected %d", read, len(contentSparse))
+		}
+		if !bytes.Equal(b[:read], contentSparse) {
+			t.Errorf("Mismatched content:\nActual: '%s'\nExpected: '%s'", b[:read], contentSparse[:read])
 		}
 	})
 }


### PR DESCRIPTION
Fix: #299

Cache the previous block size too, so when deciding to use the cached block can compare size to handle sparse blocks 