### PR TITLE
fix ext4.Remove() missing checksum in GDT

### DIFF
--- a/filesystem/ext4/checksum.go
+++ b/filesystem/ext4/checksum.go
@@ -48,3 +48,8 @@ func directoryChecksumAppender(seed, inodeNumber, inodeGeneration uint32) checks
 func nullDirectoryChecksummer(b []byte) []byte {
 	return b
 }
+
+// bitmapChecksum calculate the checksum for a bitmap
+func bitmapChecksum(b []byte, hashSeed uint32) uint32 {
+	return crc.CRC32c(hashSeed, b)
+}


### PR DESCRIPTION
This should fix the broken checksums for both bitmaps (inode and block bitmaps) and the group descriptor entries when writing. It partially solves #307 

The next issue is the writing of the directory entries, which it does not solve. It knows how to _read_ an htree directory entry, and does so successfully, but it writes it like a normal very long linear directory entry, even though the inode says it is an htree. This will cause it to fail on fsck. However, this is a good improvement to get in.