### PR TITLE
fix: adjust read/write offsets to include filesystem start

### DIFF
--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -1173,7 +1173,7 @@ func (fs *FileSystem) readInode(inodeNumber uint32) (*inode, error) {
 	offsetInode := (inodeNumber - 1) % inodesPerGroup
 	// offset is how many bytes in our inode is
 	offset := offsetInode * uint32(inodeSize)
-	read, err := fs.backend.ReadAt(inodeBytes, int64(byteStart)+int64(offset))
+	read, err := fs.backend.ReadAt(inodeBytes, fs.start+int64(byteStart)+int64(offset))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read inode %d from offset %d of block %d from block group %d: %v", inodeNumber, offset, inodeTableBlock, bg, err)
 	}
@@ -1226,7 +1226,7 @@ func (fs *FileSystem) writeInode(i *inode) error {
 	// offset is how many bytes in our inode is
 	offset := int64(offsetInode) * int64(inodeSize)
 	inodeBytes := i.toBytes(sb)
-	wrote, err := writableFile.WriteAt(inodeBytes, int64(byteStart)+offset)
+	wrote, err := writableFile.WriteAt(inodeBytes, fs.start+int64(byteStart)+offset)
 	if err != nil {
 		return fmt.Errorf("failed to write inode %d at offset %d of block %d from block group %d: %v", i.number, offset, inodeTableBlock, bg, err)
 	}
@@ -1288,7 +1288,7 @@ func (fs *FileSystem) readFileBytes(extents extents, filesize uint64) ([]byte, e
 			count = filesize - uint64(len(b))
 		}
 		b2 := make([]byte, count)
-		read, err := fs.backend.ReadAt(b2, int64(start))
+		read, err := fs.backend.ReadAt(b2, fs.start+int64(start))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read bytes for extent %d: %v", i, err)
 		}
@@ -1384,7 +1384,7 @@ func (fs *FileSystem) readBlock(blockNumber uint64) ([]byte, error) {
 	// bytesStart is beginning byte for the inodeTableBlock
 	byteStart := blockNumber * uint64(sb.blockSize)
 	blockBytes := make([]byte, sb.blockSize)
-	read, err := fs.backend.ReadAt(blockBytes, int64(byteStart))
+	read, err := fs.backend.ReadAt(blockBytes, fs.start+int64(byteStart))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read block %d: %v", blockNumber, err)
 	}

--- a/filesystem/ext4/extent.go
+++ b/filesystem/ext4/extent.go
@@ -686,7 +686,7 @@ func writeNodeToDisk(node extentBlockFinder, fs *FileSystem, parent *extentInter
 	}
 
 	data := node.toBytes()
-	_, err = writableFile.WriteAt(data, int64(blockNumber)*int64(fs.superblock.blockSize))
+	_, err = writableFile.WriteAt(data, fs.start+int64(blockNumber)*int64(fs.superblock.blockSize))
 	return err
 }
 
@@ -725,7 +725,7 @@ func findChildNode(node *extentInternalNode, added *extents) int {
 //nolint:unparam // this parameter will be used eventually
 func loadChildNode(childPtr *extentChildPtr, fs *FileSystem) (extentBlockFinder, error) {
 	data := make([]byte, fs.superblock.blockSize)
-	_, err := fs.backend.ReadAt(data, int64(childPtr.diskBlock)*int64(fs.superblock.blockSize))
+	_, err := fs.backend.ReadAt(data, fs.start+int64(childPtr.diskBlock)*int64(fs.superblock.blockSize))
 	if err != nil {
 		return nil, err
 	}

--- a/filesystem/ext4/file.go
+++ b/filesystem/ext4/file.go
@@ -61,7 +61,7 @@ func (fl *File) Read(b []byte) (int, error) {
 		// read those bytes
 		startPosOnDisk := e.startingBlock*blocksize + uint64(startPositionInExtent)
 		b2 := make([]byte, toReadInOffset)
-		read, err := fl.filesystem.backend.ReadAt(b2, int64(startPosOnDisk))
+		read, err := fl.filesystem.backend.ReadAt(b2, fl.filesystem.start+int64(startPosOnDisk))
 		if err != nil {
 			return int(readBytes), fmt.Errorf("failed to read bytes: %v", err)
 		}
@@ -170,7 +170,7 @@ func (fl *File) Write(b []byte) (int, error) {
 		startPosOnDisk := e.startingBlock*blocksize + uint64(startPositionInExtent)
 		b2 := make([]byte, toWriteInOffset)
 		copy(b2, b[writtenBytes:])
-		written, err := writableFile.WriteAt(b2, int64(startPosOnDisk))
+		written, err := writableFile.WriteAt(b2, fl.filesystem.start+int64(startPosOnDisk))
 		if err != nil {
 			return int(writtenBytes), fmt.Errorf("failed to read bytes: %v", err)
 		}


### PR DESCRIPTION
This pull request updates how disk offsets are calculated throughout the ext4 filesystem implementation. The main change is to consistently add the filesystem's starting offset (`fs.start`) to all read and write operations, ensuring correct access to disk data when the filesystem is not located at the beginning of the underlying storage. This improves support for filesystems embedded within disk images or partitions.

**Filesystem offset handling:**

* All `ReadAt` and `WriteAt` calls in `filesystem/ext4/ext4.go` now add `fs.start` to the calculated byte offsets, ensuring correct positioning for inode, block, and file data operations. [[1]](diffhunk://#diff-2d8c12205675cead6f0a1b0fe3d76bc1e5d2dfc5908b9725e8c76971b6afc116L1176-R1176) [[2]](diffhunk://#diff-2d8c12205675cead6f0a1b0fe3d76bc1e5d2dfc5908b9725e8c76971b6afc116L1229-R1229) [[3]](diffhunk://#diff-2d8c12205675cead6f0a1b0fe3d76bc1e5d2dfc5908b9725e8c76971b6afc116L1291-R1291) [[4]](diffhunk://#diff-2d8c12205675cead6f0a1b0fe3d76bc1e5d2dfc5908b9725e8c76971b6afc116L1387-R1387)
* In `filesystem/ext4/extent.go`, both loading child nodes and writing nodes to disk now include `fs.start` in their offset calculations for improved accuracy. [[1]](diffhunk://#diff-b9f3f7d84599696703bd0d0122591614adc65b2454c4ee9e5edc5d978ed5b1cbL689-R689) [[2]](diffhunk://#diff-b9f3f7d84599696703bd0d0122591614adc65b2454c4ee9e5edc5d978ed5b1cbL728-R728)
* File-level read and write operations in `filesystem/ext4/file.go` also now use `fl.filesystem.start` when accessing disk data. [[1]](diffhunk://#diff-9e67ec5d6b3085ff7e9c49ff81bc3a49b572416aa91833b92c76e75d83e98307L64-R64) [[2]](diffhunk://#diff-9e67ec5d6b3085ff7e9c49ff81bc3a49b572416aa91833b92c76e75d83e98307L173-R173)