### PR TITLE
iso9660: Truncate short filenames to 8.3 format for compatibility

### DIFF
--- a/filesystem/iso9660/finalize_test.go
+++ b/filesystem/iso9660/finalize_test.go
@@ -196,7 +196,7 @@ func TestFinalize9660(t *testing.T) {
 
 		fooCount := 75
 		for i := 0; i <= fooCount; i++ {
-			filename := fmt.Sprintf("/FOO/FILE_%d", i)
+			filename := fmt.Sprintf("/FOO/FILENAME_%02d", i)
 			contents := []byte(fmt.Sprintf("filename_%d\n", i))
 			isofile, err = fs.OpenFile(filename, os.O_CREATE|os.O_RDWR)
 			if err != nil {
@@ -248,9 +248,9 @@ func TestFinalize9660(t *testing.T) {
 
 		// get a few files I expect
 		fileContents := map[string]string{
-			"/README.MD":   "readme\n",
-			"/FOO/FILE_50": "filename_50\n",
-			"/FOO/FILE_2":  "filename_2\n",
+			"/README.MD":    "readme\n",
+			"/FOO/FILENA50": "filename_50\n",
+			"/FOO/FILENA02": "filename_2\n",
 		}
 
 		for k, v := range fileContents {


### PR DESCRIPTION
When creating ISO 9660 filesystems with Rock Ridge extensions, diskfs creates both a Rock Ridge long name and an ISO 9660 short name for compatibility with tools that don't support Rock Ridge.

Previously, the calculateShortnameExtension() function would uppercase and sanitize filenames but did not enforce the ISO 9660 Level 1 8.3 format constraints. This resulted in short names with extensions longer than 3 characters and basenames longer than 8 characters.

Some tools access files using their ISO 9660 short names and expect proper 8.3 format (8-character basename, 3-character extension). When diskfs creates ISOs with longer extensions or basenames, these tools fail to find the files.

This commit updates calculateShortnameExtension() to enforce ISO 9660 Level 1 limits:
- Extensions are truncated to a maximum of 3 characters
- Basenames are truncated to a maximum of 8 characters

This matches the behavior of traditional ISO creation tools like xorriso (default Level 1 mode) and ensures maximum compatibility.

Comprehensive tests have been added to verify the 8.3 format is correctly enforced for various filename patterns including long names, special characters, and edge cases.

Assisted-by: Claude Code