### PR TITLE
fix: support fat32 on 4k native disks

### DIFF
--- a/filesystem/fat32/common_test.go
+++ b/filesystem/fat32/common_test.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	Fat32File           = "./testdata/dist/fat32.img"
+	Fat32File4kB        = "./testdata/dist/fat32-4k.img"
 	fsckFile            = "./testdata/dist/fsck.txt"
 	rootdirFile         = "./testdata/dist/root_dir.txt"
 	rootdirFileFLS      = "./testdata/dist/root_dir_fls.txt"
@@ -199,9 +200,7 @@ func testGetValidDirectoryEntriesFromFile(dirFilePath, dirEntryPattern string, f
 		text := scanner.Text()
 		dirEntryMatch := testDirectoryEntryRE.FindStringSubmatch(text)
 		fileEntryMatch := testFileEntryRE.FindStringSubmatch(text)
-		var (
-			de *directoryEntry
-		)
+		var de *directoryEntry
 		switch {
 		case len(dirEntryMatch) == 4:
 			filenameShort := dirEntryMatch[1]

--- a/filesystem/fat32/fat32_test.go
+++ b/filesystem/fat32/fat32_test.go
@@ -111,6 +111,25 @@ func TestFat32Type(t *testing.T) {
 	}
 }
 
+func TestFat32With4kSectors(t *testing.T) {
+	bk, err := file.OpenFromPath(fat32.Fat32File4kB, true)
+	if err != nil {
+		t.Fatalf("Failed to open file with 4k sectors: %v", err)
+	}
+
+	d, err := diskfs.OpenBackend(bk)
+	if err != nil {
+		t.Fatalf("Failed to open disk with 4k sectors: %v", err)
+	}
+
+	defer d.Close()
+
+	_, err = d.GetFilesystem(0)
+	if err != nil {
+		t.Fatalf("Failed to get filesystem with 4k sectors: %v", err)
+	}
+}
+
 func TestFat32Mkdir(t *testing.T) {
 	// only do this test if os.Getenv("TEST_IMAGE") contains a real image
 	if intImage == "" {
@@ -1249,7 +1268,6 @@ func Test_Rename(t *testing.T) {
 				// do not create orig file
 			},
 			post: func(_ *testing.T, _ *fat32.FileSystem) {
-
 			},
 		},
 		{
@@ -1406,7 +1424,6 @@ func Test_Remove(t *testing.T) {
 				// do not create any file
 			},
 			post: func(_ *testing.T, _ *fat32.FileSystem) {
-
 			},
 		},
 		{

--- a/filesystem/fat32/testdata/mkfat32.sh
+++ b/filesystem/fat32/testdata/mkfat32.sh
@@ -16,6 +16,8 @@ set -x
 apk --update add dosfstools mtools sleuthkit
 dd if=/dev/zero of=/data/fat32.img bs=1M count=10
 mkfs.vfat -v -F 32 /data/fat32.img
+dd if=/dev/zero of=/data/fat32-4k.img bs=1M count=10
+mkfs.vfat -v -F 32 -S 4096 /data/fat32-4k.img
 echo "mtools_skip_check=1" >> /etc/mtools.conf
 mmd -i /data/fat32.img ::/foo
 mmd -i /data/fat32.img ::/foo/bar


### PR DESCRIPTION
This fixes the issue that `GetFilesystem()` fails on vfat created on disks with 4k sector size. `mkfs.vfat` uses 4k size when disk is native 4k.

This can be reproduced by creating a loopback device with 4k sectors and running mkfs.vfat on it.

```bash
truncate -s 10M /tmp/vfat_4k.img

sudo losetup -f --show -b 4096 /tmp/vfat_4k.img

sudo mkfs.vfat -F 32 -n TEST4K /dev/loop0

sudo losetup -d /dev/loop0
```

Then can be tested as:

```go
package main

import (
	"github.com/diskfs/go-diskfs"
	"github.com/diskfs/go-diskfs/backend/file"
	"github.com/stretchr/testify/require"
)

func main() {
	// Open the image file created with 4K sectors
	bk, err := file.OpenFromPath("/tmp/vfat_4k.img", false)
	require.NoError(err, "failed to open image file")

	defer bk.Close()

	// Try to open the disk
	diskInfo, err := diskfs.OpenBackend(bk, diskfs.WithOpenMode(diskfs.ReadWriteExclusive))
	require.NoError(err, "failed to open backend")

	defer diskInfo.Close()

	// This will fail with unpatched go-diskfs:
	// "unknown filesystem on partition 0"
	// Because go-diskfs rejects bytesPerSector != 512
	fs, err := diskInfo.GetFilesystem(0)
	require.NoError(err, "failed to get filesystem from partition 0")

	defer fs.Close()
}
```

When mkfs.vfat formats a device with 4K logical sectors, it writes bytesPerSector=4096 in the BPB, which go-diskfs rejects.