### PR TITLE
feat: support reproducible images

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -83,7 +83,6 @@ func (d *Disk) Partition(table partition.Table) error {
 // is invalid, or the partition is invalid
 func (d *Disk) WritePartitionContents(part int, reader io.Reader) (int64, error) {
 	backingRwFile, err := d.Backend.Writable()
-
 	if err != nil {
 		return -1, err
 	}
@@ -129,6 +128,8 @@ type FilesystemSpec struct {
 	FSType      filesystem.Type
 	VolumeLabel string
 	WorkDir     string
+	// The filesystem will be created in a reproducible manner following SOURCE_DATE_EPOCH guidelines.
+	Reproducible bool
 }
 
 // CreateFilesystem creates a filesystem on a disk image, the equivalent of mkfs.
@@ -171,7 +172,7 @@ func (d *Disk) CreateFilesystem(spec FilesystemSpec) (filesystem.FileSystem, err
 
 	switch spec.FSType {
 	case filesystem.TypeFat32:
-		return fat32.Create(d.Backend, size, start, d.LogicalBlocksize, spec.VolumeLabel)
+		return fat32.Create(d.Backend, size, start, d.LogicalBlocksize, spec.VolumeLabel, spec.Reproducible)
 	case filesystem.TypeISO9660:
 		return iso9660.Create(d.Backend, size, start, d.LogicalBlocksize, spec.WorkDir)
 	case filesystem.TypeExt4:

--- a/filesystem/fat32/directory.go
+++ b/filesystem/fat32/directory.go
@@ -2,7 +2,8 @@ package fat32
 
 import (
 	"fmt"
-	"time"
+
+	"github.com/diskfs/go-diskfs/util/timestamp"
 )
 
 // Directory represents a single directory in a FAT32 filesystem
@@ -50,6 +51,8 @@ func (d *Directory) createEntry(name string, cluster uint32, dir bool) (*directo
 		lfn = name
 	}
 
+	ts := timestamp.GetTime()
+
 	// allocate a slot for the new filename in the existing directory
 	entry := directoryEntry{
 		filenameLong:      lfn,
@@ -59,9 +62,9 @@ func (d *Directory) createEntry(name string, cluster uint32, dir bool) (*directo
 		fileSize:          uint32(0),
 		clusterLocation:   cluster,
 		filesystem:        d.filesystem,
-		createTime:        time.Now(),
-		modifyTime:        time.Now(),
-		accessTime:        time.Now(),
+		createTime:        ts,
+		modifyTime:        ts,
+		accessTime:        ts,
 		isSubdirectory:    dir,
 		isNew:             true,
 	}
@@ -97,7 +100,7 @@ func (d *Directory) renameEntry(oldFileName, newFileName string) error {
 	// TODO implement check for long/short filename after increment of sfn is correctly implemented
 
 	newEntries := make([]*directoryEntry, 0, len(d.entries))
-	var isReplaced = false
+	isReplaced := false
 	for _, entry := range d.entries {
 		if entry.filenameLong == newFileName {
 			continue // skip adding already existing file, will be overwritten
@@ -111,7 +114,7 @@ func (d *Directory) renameEntry(oldFileName, newFileName string) error {
 			entry.filenameLong = lfn
 			entry.filenameShort = shortName
 			entry.fileExtension = extension
-			entry.modifyTime = time.Now()
+			entry.modifyTime = timestamp.GetTime()
 			isReplaced = true
 		}
 		newEntries = append(newEntries, entry)
@@ -127,6 +130,8 @@ func (d *Directory) renameEntry(oldFileName, newFileName string) error {
 
 // createVolumeLabel create a volume label entry in the given directory, and return the handle to it
 func (d *Directory) createVolumeLabel(name string) (*directoryEntry, error) {
+	ts := timestamp.GetTime()
+
 	// allocate a slot for the new filename in the existing directory
 	entry := directoryEntry{
 		filenameLong:      "",
@@ -136,9 +141,9 @@ func (d *Directory) createVolumeLabel(name string) (*directoryEntry, error) {
 		fileSize:          uint32(0),
 		clusterLocation:   0,
 		filesystem:        d.filesystem,
-		createTime:        time.Now(),
-		modifyTime:        time.Now(),
-		accessTime:        time.Now(),
+		createTime:        ts,
+		modifyTime:        ts,
+		accessTime:        ts,
 		isSubdirectory:    false,
 		isNew:             true,
 		isVolumeLabel:     true,

--- a/util/timestamp/timestamp.go
+++ b/util/timestamp/timestamp.go
@@ -1,0 +1,21 @@
+// Package timestamp provides utilities for handling timestamps
+package timestamp
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// GetTime returns the current time in UTC, honoring SOURCE_DATE_EPOCH if set.
+// SOURCE_DATE_EPOCH is a Unix timestamp used for reproducible builds.
+// If SOURCE_DATE_EPOCH is not set or invalid, it returns time.Now().UTC().
+func GetTime() time.Time {
+	if epoch := os.Getenv("SOURCE_DATE_EPOCH"); epoch != "" {
+		if timestamp, err := strconv.ParseInt(epoch, 10, 64); err == nil {
+			return time.Unix(timestamp, 0).UTC()
+		}
+	}
+
+	return time.Now().UTC()
+}

--- a/util/timestamp/timestamp_test.go
+++ b/util/timestamp/timestamp_test.go
@@ -1,0 +1,50 @@
+package timestamp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/diskfs/go-diskfs/util/timestamp"
+)
+
+func TestTimeStamp(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		sourceDateEpoch  string
+		expectedTimeFunc func() time.Time
+	}{
+		{
+			name: "source date epoch not set",
+			expectedTimeFunc: func() time.Time {
+				return time.Now().UTC()
+			},
+		},
+		{
+			name:            "source date epoch set",
+			sourceDateEpoch: "1609459200",
+			expectedTimeFunc: func() time.Time {
+				return time.Unix(1609459200, 0).UTC()
+			},
+		},
+		{
+			name:            "source date epoch invalid",
+			sourceDateEpoch: "invalid",
+			expectedTimeFunc: func() time.Time {
+				return time.Now().UTC()
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// set SOURCE_DATE_EPOCH environment variable
+			if tt.sourceDateEpoch != "" {
+				t.Setenv("SOURCE_DATE_EPOCH", tt.sourceDateEpoch)
+			}
+
+			got := timestamp.GetTime()
+			expected := tt.expectedTimeFunc()
+			if !got.Truncate(time.Second).Equal(expected.Truncate(time.Second)) {
+				t.Errorf("GetTime() = %v, want %v", got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Support reproducible fat32 images as like `mkfs.vfat --invariant`.

This also supports creating files and directories with with the value of `SOURCE_DATE_EPOCH` when set as per https://reproducible-builds.org/ providing a way to create reproducible filesystems.