### PR TITLE
fix: buffered writes when using `io.Copy`

### DIFF
--- a/filesystem/fat32/file_test.go
+++ b/filesystem/fat32/file_test.go
@@ -1,6 +1,18 @@
 package fat32_test
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/disk"
+	"github.com/diskfs/go-diskfs/filesystem"
+	"github.com/diskfs/go-diskfs/filesystem/fat32"
+)
 
 //nolint:unused,revive // keep for future when we implement it and will need t
 func TestFileRead(t *testing.T) {
@@ -10,4 +22,133 @@ func TestFileRead(t *testing.T) {
 //nolint:unused,revive // keep for future when we implement it and will need t
 func TestFileWrite(t *testing.T) {
 
+}
+
+func TestFileSizeLimitWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	diskPath := filepath.Join(tmpDir, "test.img")
+
+	// Create a 5GB disk
+	diskSize := int64(5 * 1024 * 1024 * 1024)
+
+	bk, err := file.CreateFromPath(diskPath, diskSize)
+	if err != nil {
+		t.Fatalf("creating backend failed: %v", err)
+	}
+
+	d, err := diskfs.OpenBackend(bk)
+	if err != nil {
+		t.Fatalf("opening disk failed: %v", err)
+	}
+	defer d.Close()
+
+	spec := disk.FilesystemSpec{
+		Partition: 0,
+		FSType:    filesystem.TypeFat32,
+	}
+
+	fs, err := d.CreateFilesystem(spec)
+	if err != nil {
+		t.Fatalf("creating filesystem failed: %v", err)
+	}
+	defer fs.Close()
+
+	// Open a file for writing
+	f, err := fs.OpenFile("/testfile.dat", os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		t.Fatalf("opening file failed: %v", err)
+	}
+	defer f.Close()
+
+	// Try to write just under the 4GB limit - should succeed
+	const maxSize = (1 << 32) - 1
+	smallData := []byte("test")
+	_, err = f.Write(smallData)
+	if err != nil {
+		t.Fatalf("writing small data failed: %v", err)
+	}
+
+	// Seek to just before the 4GB boundary
+	_, err = f.Seek(maxSize-100, io.SeekStart)
+	if err != nil {
+		t.Fatalf("seeking failed: %v", err)
+	}
+
+	// Write data that would fit within the limit
+	_, err = f.Write([]byte("within limit"))
+	if err != nil {
+		t.Fatalf("writing within limit failed: %v", err)
+	}
+
+	// Try to write data that exceeds the 4GB limit
+	_, err = f.Seek(maxSize-10, io.SeekStart)
+	if err != nil {
+		t.Fatalf("seeking failed: %v", err)
+	}
+
+	bigData := make([]byte, 100)
+	_, err = f.Write(bigData)
+	if !errors.Is(err, fat32.ErrFileTooLarge) {
+		t.Errorf("expected ErrFileTooLarge, got: %v", err)
+	}
+}
+
+func TestFileSizeLimitReadFrom(t *testing.T) {
+	tmpDir := t.TempDir()
+	diskPath := filepath.Join(tmpDir, "test.img")
+
+	// Create a 5GB disk
+	diskSize := int64(5 * 1024 * 1024 * 1024)
+
+	bk, err := file.CreateFromPath(diskPath, diskSize)
+	if err != nil {
+		t.Fatalf("creating backend failed: %v", err)
+	}
+
+	d, err := diskfs.OpenBackend(bk)
+	if err != nil {
+		t.Fatalf("opening disk failed: %v", err)
+	}
+	defer d.Close()
+
+	spec := disk.FilesystemSpec{
+		Partition: 0,
+		FSType:    filesystem.TypeFat32,
+	}
+
+	fs, err := d.CreateFilesystem(spec)
+	if err != nil {
+		t.Fatalf("creating filesystem failed: %v", err)
+	}
+	defer fs.Close()
+
+	// Open a file for writing
+	f, err := fs.OpenFile("/testfile.dat", os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		t.Fatalf("opening file failed: %v", err)
+	}
+	defer f.Close()
+
+	// Try to copy data that would exceed 4GB using io.Copy (which uses ReadFrom)
+	const maxSize = (1 << 32) - 1
+	const dataSize = maxSize + 1000 // Slightly over 4GB
+
+	// Create an infinite zero reader limited to dataSize bytes
+	reader := io.LimitReader(zeroReader{}, dataSize)
+
+	// This should fail with ErrFileTooLarge
+	_, err = io.Copy(f, reader)
+	if !errors.Is(err, fat32.ErrFileTooLarge) {
+		t.Errorf("expected ErrFileTooLarge, got: %v", err)
+	}
+}
+
+// zeroReader is a reader that always returns zeros
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }

--- a/filesystem/fat32/write_benchmark_test.go
+++ b/filesystem/fat32/write_benchmark_test.go
@@ -1,0 +1,117 @@
+package fat32_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/disk"
+	"github.com/diskfs/go-diskfs/filesystem"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	benchmarkFileSize = (4 * 1024 * 1024 * 1024) - 1 // 4GB
+)
+
+// createTestFile creates a temporary file with specified size using random data
+func createTestFile(b *testing.B, size int64) string {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	path := filepath.Join(tmpDir, "source.dat")
+
+	f, err := os.Create(path)
+	require.NoError(b, err, "creating test file failed")
+
+	defer f.Close()
+
+	require.NoError(b, f.Truncate(size), "truncating test file failed")
+
+	return path
+}
+
+// setupFAT32Disk creates a temporary FAT32 filesystem
+func setupFAT32Disk(b *testing.B) (fs filesystem.FileSystem, cleanup func()) {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	diskPath := filepath.Join(tmpDir, "test.img")
+
+	// Create a 5GB disk to have plenty of space for 4GB file
+	diskSize := int64(5 * 1024 * 1024 * 1024)
+
+	bk, err := file.CreateFromPath(diskPath, diskSize)
+	require.NoError(b, err, "creating backend failed")
+
+	d, err := diskfs.OpenBackend(bk)
+	require.NoError(b, err, "opening disk failed")
+
+	spec := disk.FilesystemSpec{
+		Partition: 0,
+		FSType:    filesystem.TypeFat32,
+	}
+
+	fs, err = d.CreateFilesystem(spec)
+	require.NoError(b, err, "creating filesystem failed")
+
+	return fs, func() {
+		require.NoError(b, fs.Close())
+		require.NoError(b, d.Close())
+	}
+}
+
+// BenchmarkFAT32WriteWithReadFile benchmarks writing using os.ReadFile + Write
+func BenchmarkFAT32WriteWithReadFile(b *testing.B) {
+	// Create source file once for all iterations
+	sourceFile := createTestFile(b, benchmarkFileSize)
+
+	for b.Loop() {
+		// Create new filesystem for each iteration
+		fs, cleanupFunc := setupFAT32Disk(b)
+
+		// Read entire file into memory
+		data, err := os.ReadFile(sourceFile)
+		require.NoError(b, err, "reading source file failed")
+
+		// Open destination file
+		destFile, err := fs.OpenFile("/testfile.dat", os.O_CREATE|os.O_RDWR)
+		require.NoError(b, err, "opening destination file failed")
+
+		// Write all at once
+		_, err = destFile.Write(data)
+		require.NoError(b, err, "writing to destination file failed")
+		require.NoError(b, destFile.Close())
+
+		cleanupFunc()
+	}
+}
+
+// BenchmarkFAT32WriteWithIOCopy benchmarks writing using io.Copy
+func BenchmarkFAT32WriteWithIOCopy(b *testing.B) {
+	// Create source file once for all iterations
+	sourceFile := createTestFile(b, benchmarkFileSize)
+
+	for b.Loop() {
+		// Create new filesystem for each iteration
+		fs, cleanupFunc := setupFAT32Disk(b)
+
+		// Open source file
+		srcFile, err := os.Open(sourceFile)
+		require.NoError(b, err, "opening source file failed")
+
+		// Open destination file
+		destFile, err := fs.OpenFile("/testfile.dat", os.O_CREATE|os.O_RDWR)
+		require.NoError(b, err, "opening destination file failed")
+
+		_, err = io.Copy(destFile, srcFile)
+		require.NoError(b, err, "copying to destination file failed")
+		require.NoError(b, srcFile.Close())
+		require.NoError(b, destFile.Close())
+
+		cleanupFunc()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,13 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.17
 	github.com/pkg/xattr v0.4.9
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
+	github.com/stretchr/testify v1.7.1
 	github.com/ulikunitz/xz v0.5.15
 	golang.org/x/sys v0.19.0
 )
 
-require github.com/stretchr/testify v1.7.1 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
When copying files to a fat filesystem and if using `io.Copy` on the `filesystem.OpenFile` it was slow which the entries were flushed for each write which is in-efficient. Only flush once on `Close()`.