### PR TITLE
return specific error types from GetFilesystem

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -204,12 +204,12 @@ func (d *Disk) GetFilesystem(part int) (filesystem.FileSystem, error) {
 		size = d.Size
 		start = 0
 	case d.Table == nil:
-		return nil, fmt.Errorf("cannot read filesystem on a partition without a partition table")
+		return nil, &NoPartitionTableError{}
 	default:
 		partitions := d.Table.GetPartitions()
 		// API indexes from 1, but slice from 0
 		if part > len(partitions) {
-			return nil, fmt.Errorf("cannot get filesystem on partition %d greater than maximum partition %d", part, len(partitions))
+			return nil, NewMaxPartitionsExceededError(part, len(partitions))
 		}
 		size = partitions[part-1].GetSize()
 		start = partitions[part-1].GetStart()
@@ -242,7 +242,7 @@ func (d *Disk) GetFilesystem(part int) (filesystem.FileSystem, error) {
 		return ext4FS, nil
 	}
 	log.Debugf("ext4 failed: %v", err)
-	return nil, fmt.Errorf("unknown filesystem on partition %d", part)
+	return nil, NewUnknownFilesystemError(part)
 }
 
 // Close the disk. Once successfully closed, it can no longer be used.

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -8,6 +8,7 @@ package disk_test
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -521,9 +522,9 @@ func TestGetFilesystem(t *testing.T) {
 			LogicalBlocksize:  512,
 			PhysicalBlocksize: 512,
 		}
-		expected := fmt.Errorf("cannot read filesystem on a partition without a partition table")
 		fs, err := d.GetFilesystem(1)
-		if err == nil || err.Error() != expected.Error() {
+		expected := &disk.NoPartitionTableError{}
+		if err == nil || !errors.Is(err, expected) {
 			t.Errorf("Mismatched error: actual %v expected %v", err, expected)
 		}
 		if fs != nil {

--- a/disk/error.go
+++ b/disk/error.go
@@ -1,0 +1,39 @@
+package disk
+
+import "fmt"
+
+type UnknownFilesystemError struct {
+	partition int
+}
+
+func (e *UnknownFilesystemError) Error() string {
+	return fmt.Sprintf("unknown filesystem type on partition %d", e.partition)
+}
+
+func NewUnknownFilesystemError(partition int) *UnknownFilesystemError {
+	return &UnknownFilesystemError{
+		partition: partition,
+	}
+}
+
+type NoPartitionTableError struct{}
+
+func (e *NoPartitionTableError) Error() string {
+	return "no partition table found on disk"
+}
+
+type MaxPartitionsExceededError struct {
+	requested int
+	max       int
+}
+
+func (e *MaxPartitionsExceededError) Error() string {
+	return fmt.Sprintf("requested partition %d exceeds maximum partitions %d", e.requested, e.max)
+}
+
+func NewMaxPartitionsExceededError(requested, maxPart int) *MaxPartitionsExceededError {
+	return &MaxPartitionsExceededError{
+		requested: requested,
+		max:       maxPart,
+	}
+}


### PR DESCRIPTION
This makes it easier to check why `GetFilesystem` failed