### PR TITLE
squashfs: properly count written bytes

### DIFF
--- a/filesystem/squashfs/finalize.go
+++ b/filesystem/squashfs/finalize.go
@@ -388,6 +388,7 @@ func copyFileData(from backend.File, to backend.WritableFile, fromOffset, toOffs
 			if len(out) < len(buf) {
 				isCompressed = true
 				buf = out
+				n = len(out)
 			}
 		}
 		blocks = append(blocks, &blockData{size: uint32(len(buf)), compressed: isCompressed})


### PR DESCRIPTION
After compressing a block, the output buffer is much smaller. However, we still assumed the length of the block to be the whole size of the original. This led to a "slice out of bounds" error.