### PR TITLE
ext4: return error instead of panicking on special file inodes

### DIFF
--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -1272,6 +1272,9 @@ func (fs *FileSystem) OpenFile(p string, flag int) (filesystem.File, error) {
 		}
 		return fs.OpenFile(linkTarget, flag)
 	}
+	if inode.extents == nil {
+		return nil, fmt.Errorf("cannot open special file %s (inode %d): no extent tree", p, inodeNumber)
+	}
 	offset := int64(0)
 	if flag&os.O_APPEND == os.O_APPEND {
 		offset = int64(inode.size)
@@ -1305,6 +1308,9 @@ func (fs *FileSystem) openFileViaInode(inodeNumber uint32, flag int) (filesystem
 	// if a symlink, read the target, rather than the inode itself, which does not point to anything
 	if inode.fileType == fileTypeSymbolicLink {
 		return nil, fmt.Errorf("cannot open file via inode: inode %d is a symbolic link", inodeNumber)
+	}
+	if inode.extents == nil {
+		return nil, fmt.Errorf("cannot open special file (inode %d): no extent tree", inodeNumber)
 	}
 	offset := int64(0)
 	if flag&os.O_APPEND == os.O_APPEND {

--- a/filesystem/ext4/ext4_integration_test.go
+++ b/filesystem/ext4/ext4_integration_test.go
@@ -122,6 +122,8 @@ func compareFileSystems(src, dst fs.FS) error {
 	return compareDir(src, dst, ".")
 }
 
+// compareDir compares two directories in src and dst filesystems.
+// Special files (devices, fifos, sockets) are skipped since CopyFileSystem does not copy them.
 func compareDir(src, dst fs.FS, dir string) error {
 	srcEntries, err := fs.ReadDir(src, dir)
 	if err != nil {
@@ -132,16 +134,21 @@ func compareDir(src, dst fs.FS, dir string) error {
 		return fmt.Errorf("read dir %s (dst): %w", dir, err)
 	}
 
+	isSpecialFile := func(e fs.DirEntry) bool {
+		t := e.Type()
+		return t&(fs.ModeDevice|fs.ModeNamedPipe|fs.ModeSocket) != 0
+	}
+
 	srcMap := make(map[string]fs.DirEntry, len(srcEntries))
 	for _, entry := range srcEntries {
-		if excludedPaths[entry.Name()] {
+		if excludedPaths[entry.Name()] || isSpecialFile(entry) {
 			continue
 		}
 		srcMap[entry.Name()] = entry
 	}
 	dstMap := make(map[string]fs.DirEntry, len(dstEntries))
 	for _, entry := range dstEntries {
-		if excludedPaths[entry.Name()] {
+		if excludedPaths[entry.Name()] || isSpecialFile(entry) {
 			continue
 		}
 		dstMap[entry.Name()] = entry

--- a/filesystem/ext4/specialfile_test.go
+++ b/filesystem/ext4/specialfile_test.go
@@ -1,0 +1,31 @@
+package ext4
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/diskfs/go-diskfs/backend/file"
+)
+
+func TestOpenFileSpecialFileReturnsError(t *testing.T) {
+	f, err := os.Open(imgFile)
+	if err != nil {
+		t.Fatalf("Error opening test image: %v", err)
+	}
+	defer f.Close()
+
+	b := file.New(f, true)
+	fs, err := Read(b, 100*MB, 0, 512)
+	if err != nil {
+		t.Fatalf("Error reading filesystem: %v", err)
+	}
+
+	_, err = fs.OpenFile("/chardev", os.O_RDONLY)
+	if err == nil {
+		t.Fatal("OpenFile on character device should return an error, not succeed")
+	}
+	if !strings.Contains(err.Error(), "cannot open special file") {
+		t.Errorf("expected 'cannot open special file' error, got: %v", err)
+	}
+}

--- a/filesystem/ext4/testdata/buildimg.sh
+++ b/filesystem/ext4/testdata/buildimg.sh
@@ -31,6 +31,8 @@ ln -s nonexistent deadlink
 ln -s /some/really/long/path/that/does/not/exist/and/does/not/fit/in/symlink deadlonglink # the target here is >60 chars and so will not fit within the inode
 # hardlink
 ln random.dat hardlink.dat
+# character device for special file tests
+mknod chardev c 1 3
 cd /data
 umount /mnt
 


### PR DESCRIPTION
- needs: https://github.com/diskfs/go-diskfs/pull/350

OpenFile and openFileViaInode panic with a nil pointer dereference when called on character device, block device, FIFO, or socket inodes. These inode types store device major/minor numbers instead of an extent tree, so inode.extents is nil and the call to inode.extents.blocks() crashes.

Add a nil guard that returns a descriptive error before accessing the extent tree.

Before this patch, the test TestOpenFileSpecialFileReturnsError failed with panic:

```
--- FAIL: TestOpenFileSpecialFileReturnsError (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x57c15c]

goroutine 21 [running]:
testing.tRunner.func1.2({0x605880, 0x814950})
	/usr/lib/go-1.26/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/lib/go-1.26/src/testing/testing.go:1977 +0x349
panic({0x605880?, 0x814950?})
	/usr/lib/go-1.26/src/runtime/panic.go:860 +0x13a
github.com/diskfs/go-diskfs/filesystem/ext4.(*FileSystem).OpenFile(0x341696991a40, {0x6464bf, 0x8}, 0x0)
	/home/pawel/src/go-diskfs/filesystem/ext4/ext4.go:1280 +0x27c
github.com/diskfs/go-diskfs/filesystem/ext4.TestOpenFileSpecialFileReturnsError(0x341696904248)
	/home/pawel/src/go-diskfs/filesystem/ext4/specialfile_test.go:24 +0x185
testing.tRunner(0x341696904248, 0x65e1b0)
	/usr/lib/go-1.26/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/lib/go-1.26/src/testing/testing.go:2101 +0x4c5
FAIL	github.com/diskfs/go-diskfs/filesystem/ext4	0.011s
FAIL
```