### PR TITLE
ext4/stat: expose device numbers, inode number, and hard link count

### DIFF
--- a/filesystem/ext4/directoryentry.go
+++ b/filesystem/ext4/directoryentry.go
@@ -191,6 +191,7 @@ func (de *directoryEntryInfo) Info() (iofs.FileInfo, error) {
 		size:    int64(de.size),
 		isDir:   de.directoryEntry.fileType == dirFileTypeDirectory,
 		mode:    mode,
+		sys:     de.stat(),
 	}, nil
 }
 

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -1611,10 +1611,7 @@ func (fs *FileSystem) Stat(p string) (iofs.FileInfo, error) {
 		size:    int64(in.size),
 		isDir:   entry.fileType == dirFileTypeDirectory,
 		mode:    in.permissionsToMode(),
-		sys: &StatT{
-			UID: in.owner,
-			GID: in.group,
-		},
+		sys:     in.stat(),
 	}, nil
 }
 

--- a/filesystem/ext4/file.go
+++ b/filesystem/ext4/file.go
@@ -244,9 +244,6 @@ func (fl *File) Stat() (fs.FileInfo, error) {
 		size:    int64(fl.size),
 		isDir:   fl.fileType == dirFileTypeDirectory,
 		mode:    fl.permissionsToMode(),
-		sys: &StatT{
-			UID: fl.owner,
-			GID: fl.group,
-		},
+		sys:     fl.stat(),
 	}, nil
 }

--- a/filesystem/ext4/fileinfo.go
+++ b/filesystem/ext4/fileinfo.go
@@ -17,8 +17,12 @@ type FileInfo struct {
 }
 
 type StatT struct {
-	UID uint32
-	GID uint32
+	UID   uint32
+	GID   uint32
+	Major uint32
+	Minor uint32
+	Ino   uint32
+	Nlink uint16
 }
 
 // IsDir abbreviation for Mode().IsDir()

--- a/filesystem/ext4/inode.go
+++ b/filesystem/ext4/inode.go
@@ -140,6 +140,50 @@ type inode struct {
 	linkTarget             string
 }
 
+// deviceNumber extracts the device major/minor from blockPointers using the
+// Linux kernel encoding from include/linux/kdev_t.h:
+//
+// Old encoding (blockPointers[0] != 0):
+//
+//	dev_t old_decode_dev(u16 val) {
+//	    return MKDEV((val >> 8) & 255, val & 255);
+//	}
+//
+// New encoding (blockPointers[1]):
+//
+//	dev_t new_decode_dev(u32 dev) {
+//	    unsigned major = (dev & 0xfff00) >> 8;
+//	    unsigned minor = (dev & 0xff) | ((dev >> 12) & 0xfff00);
+//	    return MKDEV(major, minor);
+//	}
+func (i *inode) deviceNumber() (major, minor uint32) {
+	if i.fileType != fileTypeCharacterDevice && i.fileType != fileTypeBlockDevice {
+		return 0, 0
+	}
+	old := i.blockPointers[0]
+	if old != 0 {
+		major = (old >> 8) & 0xff
+		minor = old & 0xff
+		return
+	}
+	raw := i.blockPointers[1]
+	major = (raw >> 8) & 0xfff
+	minor = (raw & 0xff) | ((raw >> 12) & 0xfff00)
+	return
+}
+
+func (i *inode) stat() *StatT {
+	major, minor := i.deviceNumber()
+	return &StatT{
+		UID:   i.owner,
+		GID:   i.group,
+		Major: major,
+		Minor: minor,
+		Ino:   i.number,
+		Nlink: i.hardLinks,
+	}
+}
+
 //nolint:unused // will be used in the future, not yet
 func (i *inode) equal(a *inode) bool {
 	if (i == nil && a != nil) || (a == nil && i != nil) {

--- a/filesystem/ext4/inode_test.go
+++ b/filesystem/ext4/inode_test.go
@@ -1,0 +1,72 @@
+package ext4
+
+import "testing"
+
+func TestInodeDeviceNumber(t *testing.T) {
+	tests := []struct {
+		name          string
+		fileType      fileType
+		blockPointers [15]uint32
+		wantMajor     uint32
+		wantMinor     uint32
+	}{
+		{
+			name:      "non-device returns zero",
+			fileType:  fileTypeRegularFile,
+			wantMajor: 0,
+			wantMinor: 0,
+		},
+		{
+			name:     "old-style char device",
+			fileType: fileTypeCharacterDevice,
+			// major=1, minor=3
+			blockPointers: [15]uint32{(1 << 8) | 3},
+			wantMajor:     1,
+			wantMinor:     3,
+		},
+		{
+			name:     "old-style block device",
+			fileType: fileTypeBlockDevice,
+			// major=8, minor=0
+			blockPointers: [15]uint32{(8 << 8) | 0}, //nolint:staticcheck // (minor=0)
+			wantMajor:     8,
+			wantMinor:     0,
+		},
+		{
+			name:     "new-style char device with large minor",
+			fileType: fileTypeCharacterDevice,
+			// major=136, minor=0
+			blockPointers: [15]uint32{0, (0 & 0xff) | (136 << 8) | ((0 & ^uint32(0xff)) << 12)},
+			wantMajor:     136,
+			wantMinor:     0,
+		},
+		{
+			name:     "new-style block device with large minor",
+			fileType: fileTypeBlockDevice,
+			// major=259, minor=1
+			blockPointers: [15]uint32{0, (1 & 0xff) | (259 << 8) | ((1 & ^uint32(0xff)) << 12)},
+			wantMajor:     259,
+			wantMinor:     1,
+		},
+		{
+			name:     "new-style with large minor number",
+			fileType: fileTypeBlockDevice,
+			// major=8, minor=256
+			blockPointers: [15]uint32{0, (256 & 0xff) | (8 << 8) | ((256 & ^uint32(0xff)) << 12)},
+			wantMajor:     8,
+			wantMinor:     256,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := &inode{
+				fileType:      tt.fileType,
+				blockPointers: tt.blockPointers,
+			}
+			major, minor := in.deviceNumber()
+			if major != tt.wantMajor || minor != tt.wantMinor {
+				t.Errorf("deviceNumber() = (%d, %d), want (%d, %d)", major, minor, tt.wantMajor, tt.wantMinor)
+			}
+		})
+	}
+}

--- a/filesystem/ext4/public_methods_test.go
+++ b/filesystem/ext4/public_methods_test.go
@@ -316,5 +316,16 @@ func TestStat(t *testing.T) {
 		// uid and gid should be non-negative (they are uint32)
 		_ = stat.UID
 		_ = stat.GID
+
+		if stat.Ino == 0 {
+			t.Error("expected non-zero inode number")
+		}
+		if stat.Nlink == 0 {
+			t.Error("expected non-zero hard link count")
+		}
+		// regular file should have zero device numbers
+		if stat.Major != 0 || stat.Minor != 0 {
+			t.Errorf("expected zero device numbers for regular file, got major=%d minor=%d", stat.Major, stat.Minor)
+		}
 	})
 }


### PR DESCRIPTION
Add Major/Minor, Ino, and Nlink fields to StatT so callers can fully reconstruct ext4 image contents. Without these, device nodes (char/block) cannot be recreated and hard links are silently duplicated as separate files.