### PR TITLE
ext4: implement extended attribute reading

### DIFF
--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -1633,29 +1633,11 @@ func (fs *FileSystem) readInode(inodeNumber uint32) (*inode, error) {
 	if inodeNumber == 0 {
 		return nil, fmt.Errorf("cannot read inode 0")
 	}
-	sb := fs.superblock
-	inodeSize := sb.inodeSize
-	inodesPerGroup := sb.inodesPerGroup
-	// figure out which block group the inode is on
-	bg := (inodeNumber - 1) / inodesPerGroup
-	// read the group descriptor to find out the location of the inode table
-	gd := fs.groupDescriptors.descriptors[bg]
-	inodeTableBlock := gd.inodeTableLocation
-	inodeBytes := make([]byte, inodeSize)
-	// bytesStart is beginning byte for the inodeTableBlock
-	byteStart := inodeTableBlock * uint64(sb.blockSize)
-	// offsetInode is how many inodes in our inode is
-	offsetInode := (inodeNumber - 1) % inodesPerGroup
-	// offset is how many bytes in our inode is
-	offset := offsetInode * uint32(inodeSize)
-	read, err := fs.backend.ReadAt(inodeBytes, int64(byteStart)+int64(offset))
+	inodeBytes, err := fs.readInodeRaw(inodeNumber)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read inode %d from offset %d of block %d from block group %d: %v", inodeNumber, offset, inodeTableBlock, bg, err)
+		return nil, fmt.Errorf("could not read inode %d: %w", inodeNumber, err)
 	}
-	if read != int(inodeSize) {
-		return nil, fmt.Errorf("read %d bytes for inode %d instead of inode size of %d", read, inodeNumber, inodeSize)
-	}
-	inode, err := inodeFromBytes(inodeBytes, sb, inodeNumber)
+	inode, err := inodeFromBytes(inodeBytes, fs.superblock, inodeNumber)
 	if err != nil {
 		return nil, fmt.Errorf("could not interpret inode data: %v", err)
 	}
@@ -3395,4 +3377,158 @@ func validatePath(name string) error {
 		return iofs.ErrInvalid
 	}
 	return nil
+}
+
+// GetXattr reads extended attributes for the file at path p.
+//
+// Extended attributes are stored either inline in the inode (ibody) or in a
+// separate block referenced by inode.i_file_acl. This method reads both locations
+// and merges the results, with ibody xattrs taking precedence.
+//
+// References:
+//   - Kernel source: https://github.com/torvalds/linux/blob/master/fs/ext4/xattr.c (ext4_xattr_get)
+//   - Disk layout: https://www.kernel.org/doc/html/latest/filesystems/ext4/dynamic.html#extended-attributes
+func (fs *FileSystem) GetXattr(p string) (map[string][]byte, error) {
+	_, entry, err := fs.getEntryAndParent(p)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("file does not exist: %s", p)
+	}
+	inodeBytes, err := fs.readInodeRaw(entry.inode)
+	if err != nil {
+		return nil, fmt.Errorf("could not read inode %d: %w", entry.inode, err)
+	}
+	in, err := inodeFromBytes(inodeBytes, fs.superblock, entry.inode)
+	if err != nil {
+		return nil, fmt.Errorf("could not interpret inode data: %w", err)
+	}
+	return fs.readXattrs(in, inodeBytes)
+}
+
+// readXattrs reads all extended attributes from an inode.
+//
+// Extended attributes can be stored in two locations:
+// 1. Inline in the inode body (ibody) - stored after i_extra_isize
+// 2. In a dedicated block referenced by inode.i_file_acl
+//
+// Both locations are read and merged. The same key should not exist in both
+// locations, but if it does, the ibody value is kept.
+func (fs *FileSystem) readXattrs(in *inode, inodeBytes []byte) (map[string][]byte, error) {
+	result := make(map[string][]byte)
+
+	ibodyXattrs, err := fs.readIbodyXattrs(inodeBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error reading ibody xattrs: %w", err)
+	}
+	for k, v := range ibodyXattrs {
+		result[k] = v
+	}
+
+	if in.extendedAttributeBlock != 0 {
+		blockXattrs, err := fs.readBlockXattrs(in.extendedAttributeBlock)
+		if err != nil {
+			return nil, fmt.Errorf("error reading xattr block: %w", err)
+		}
+		for k, v := range blockXattrs {
+			if _, exists := result[k]; !exists {
+				result[k] = v
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// readIbodyXattrs reads extended attributes stored inline in the inode.
+//
+// For inodes larger than 128 bytes, the extra space after i_extra_isize can be
+// used to store extended attributes. The layout is:
+//
+//	[128-byte base inode][i_extra_isize bytes][xattr magic][xattr entries]
+//
+// The inline storage is indicated by the ext4_xattr_ibody_header magic number
+// (0xEA020000). If not present, the inode has no inline xattrs.
+//
+// Reference: ext4_xattr_ibody_find in fs/ext4/xattr.c
+func (fs *FileSystem) readIbodyXattrs(inodeBytes []byte) (map[string][]byte, error) {
+	sb := fs.superblock
+	if sb.inodeSize <= ext2InodeSize {
+		return nil, nil
+	}
+
+	if len(inodeBytes) < int(ext2InodeSize)+4 {
+		return nil, nil
+	}
+	extraIsize := binary.LittleEndian.Uint16(inodeBytes[ext2InodeSize : ext2InodeSize+2])
+
+	xattrStart := int(ext2InodeSize) + int(extraIsize)
+	xattrEnd := int(sb.inodeSize)
+	if xattrStart >= xattrEnd || xattrEnd-xattrStart < 4 {
+		return nil, nil
+	}
+
+	magic := binary.LittleEndian.Uint32(inodeBytes[xattrStart : xattrStart+4])
+	if magic != xattrMagic {
+		return nil, nil
+	}
+
+	data := inodeBytes[xattrStart+4 : xattrEnd]
+	return parseXattrEntries(data, data)
+}
+
+// readBlockXattrs reads extended attributes from a dedicated block.
+//
+// The block format is:
+//
+//	[ext4_xattr_header (32 bytes)][xattr entries][xattr values]
+//
+// The ext4_xattr_header contains a magic number (0xEA020000), reference count,
+// and checksums. Entries are stored in sorted order (by name_index, then name).
+//
+// Reference: ext4_xattr_block_find in fs/ext4/xattr.c
+func (fs *FileSystem) readBlockXattrs(block uint64) (map[string][]byte, error) {
+	blockSize := int(fs.superblock.blockSize)
+	data := make([]byte, blockSize)
+	offset := int64(block) * int64(blockSize)
+	_, err := fs.backend.ReadAt(data, offset)
+	if err != nil {
+		return nil, fmt.Errorf("could not read xattr block at %d: %w", block, err)
+	}
+
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != xattrMagic {
+		return nil, fmt.Errorf("invalid xattr block magic: %x", magic)
+	}
+
+	entryData := data[xattrHeaderSize:]
+	return parseXattrEntries(entryData, data)
+}
+
+// readInodeRaw reads the raw bytes of an inode from disk.
+//
+// This is a helper function extracted from readInode to allow reading the full
+// inode structure including the extended area (i_extra_isize) which may contain
+// inline extended attributes.
+func (fs *FileSystem) readInodeRaw(inodeNumber uint32) ([]byte, error) {
+	sb := fs.superblock
+	inodeSize := sb.inodeSize
+	inodesPerGroup := sb.inodesPerGroup
+	bg := (inodeNumber - 1) / inodesPerGroup
+	gd := fs.groupDescriptors.descriptors[bg]
+	inodeTableBlock := gd.inodeTableLocation
+	byteStart := inodeTableBlock * uint64(sb.blockSize)
+	offsetInode := (inodeNumber - 1) % inodesPerGroup
+	offset := offsetInode * uint32(inodeSize)
+
+	inodeBytes := make([]byte, inodeSize)
+	read, err := fs.backend.ReadAt(inodeBytes, int64(byteStart)+int64(offset))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read inode %d from offset %d of block %d from block group %d: %w", inodeNumber, offset, inodeTableBlock, bg, err)
+	}
+	if read != int(inodeSize) {
+		return nil, fmt.Errorf("read %d bytes for inode %d instead of inode size of %d", read, inodeNumber, inodeSize)
+	}
+	return inodeBytes, nil
 }

--- a/filesystem/ext4/xattr.go
+++ b/filesystem/ext4/xattr.go
@@ -1,0 +1,120 @@
+package ext4
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Extended Attributes (xattrs) implementation.
+//
+// References:
+// - Kernel documentation: https://www.kernel.org/doc/html/latest/filesystems/ext4/dynamic.html#extended-attributes
+// - Legacy wiki: https://ext4.wiki.kernel.org/index.php/Ext4_Disk_Layout#Extended_Attributes
+// - Kernel source (structures): https://github.com/torvalds/linux/blob/master/fs/ext4/xattr.h
+// - Kernel source (implementation): https://github.com/torvalds/linux/blob/master/fs/ext4/xattr.c
+// - e2fsprogs implementation: https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/lib/ext2fs/ext_attr.c
+
+const (
+	// xattrMagic is the magic number identifying extended attribute blocks.
+	// See ext4_xattr_header in fs/ext4/xattr.h
+	xattrMagic = 0xEA020000
+
+	// xattrHeaderSize is the size of ext4_xattr_header (32 bytes).
+	xattrHeaderSize = 32
+
+	// xattrEntrySize is the fixed size of ext4_xattr_entry before the variable-length name.
+	// See struct ext4_xattr_entry in fs/ext4/xattr.h
+	xattrEntrySize = 16
+
+	// Attribute name index values from fs/ext4/xattr.h
+	xattrIndexUser            = 1 // EXT4_XATTR_INDEX_USER
+	xattrIndexPosixACLAccess  = 2 // EXT4_XATTR_INDEX_POSIX_ACL_ACCESS
+	xattrIndexPosixACLDefault = 3 // EXT4_XATTR_INDEX_POSIX_ACL_DEFAULT
+	xattrIndexTrusted         = 4 // EXT4_XATTR_INDEX_TRUSTED
+	xattrIndexSecurity        = 6 // EXT4_XATTR_INDEX_SECURITY
+	xattrIndexSystem          = 7 // EXT4_XATTR_INDEX_SYSTEM
+)
+
+// xattrPrefixes maps name index values to their corresponding key prefixes.
+// This reduces on-disk space consumption by storing only the index instead of
+// the full prefix string.
+//
+// POSIX ACL entries have no trailing dot because their e_name_len is always 0;
+// the full attribute name is exactly the prefix (e.g. "system.posix_acl_access").
+//
+// See ext4_xattr_prefix_type in fs/ext4/xattr.h
+var xattrPrefixes = map[uint8]string{
+	0:                         "",
+	xattrIndexUser:            "user.",
+	xattrIndexPosixACLAccess:  "system.posix_acl_access",
+	xattrIndexPosixACLDefault: "system.posix_acl_default",
+	xattrIndexTrusted:         "trusted.",
+	xattrIndexSecurity:        "security.",
+	xattrIndexSystem:          "system.",
+}
+
+// parseXattrEntries parses extended attribute entries from a byte slice.
+//
+// entries contains the ext4_xattr_entry structures; values is the region from which
+// e_value_offs is relative. For inline (ibody) xattrs, both point to the same region.
+// For block xattrs, entries points to the region after the header, and values points
+// to the entire block (including header).
+//
+// The on-disk format is defined in struct ext4_xattr_entry in fs/ext4/xattr.h:
+//
+//	struct ext4_xattr_entry {
+//	    __u8 e_name_len;      /* length of name */
+//	    __u8 e_name_index;    /* attribute name index */
+//	    __le16 e_value_offs;  /* offset in disk block of value */
+//	    __le32 e_value_inum;  /* inode in which the value is stored */
+//	    __le32 e_value_size;  /* size of attribute value */
+//	    __le32 e_hash;        /* hash value of name and value */
+//	    char e_name[];        /* attribute name */
+//	};
+func parseXattrEntries(entries, values []byte) (map[string][]byte, error) {
+	result := make(map[string][]byte)
+	pos := 0
+	for pos+xattrEntrySize <= len(entries) {
+		nameLen := entries[pos]
+		nameIndex := entries[pos+1]
+		// The entry list is terminated by a zero-filled entry (e_name_len == 0
+		// and e_name_index == 0). See EXT4_IS_LAST_ENTRY in fs/ext4/xattr.h.
+		// POSIX ACL entries have e_name_len == 0 but e_name_index != 0.
+		if nameLen == 0 && nameIndex == 0 {
+			break
+		}
+		valueOffs := binary.LittleEndian.Uint16(entries[pos+2 : pos+4])
+		valueInum := binary.LittleEndian.Uint32(entries[pos+4 : pos+8])
+		valueSize := binary.LittleEndian.Uint32(entries[pos+8 : pos+12])
+
+		nameStart := pos + xattrEntrySize
+		nameEnd := nameStart + int(nameLen)
+		if nameEnd > len(entries) {
+			return nil, fmt.Errorf("xattr entry name extends past buffer")
+		}
+
+		prefix, ok := xattrPrefixes[nameIndex]
+		if !ok {
+			prefix = fmt.Sprintf("unknown_%d.", nameIndex)
+		}
+		fullName := prefix + string(entries[nameStart:nameEnd])
+
+		if valueInum != 0 {
+			return nil, fmt.Errorf("xattr %q: ea_inode values not supported", fullName)
+		}
+		if valueSize > 0 {
+			vStart := int(valueOffs)
+			vEnd := vStart + int(valueSize)
+			if vEnd > len(values) {
+				return nil, fmt.Errorf("xattr value for %q extends past buffer", fullName)
+			}
+			val := make([]byte, valueSize)
+			copy(val, values[vStart:vEnd])
+			result[fullName] = val
+		}
+
+		// Advance to next entry, aligned to 4 bytes.
+		pos = (nameEnd + 3) &^ 3
+	}
+	return result, nil
+}

--- a/filesystem/ext4/xattr_test.go
+++ b/filesystem/ext4/xattr_test.go
@@ -1,0 +1,351 @@
+package ext4
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseXattrEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		entries  []byte
+		values   []byte
+		expected map[string]string
+		wantErr  bool
+	}{
+		{
+			name:     "empty entries",
+			entries:  make([]byte, 16),
+			values:   make([]byte, 256),
+			expected: map[string]string{},
+		},
+		{
+			name:    "single trusted xattr",
+			entries: buildXattrEntry(xattrIndexTrusted, "overlay.opaque", []byte("y")),
+			expected: map[string]string{
+				"trusted.overlay.opaque": "y",
+			},
+		},
+		{
+			name:    "single security xattr",
+			entries: buildXattrEntry(xattrIndexSecurity, "capability", []byte("cap_data")),
+			expected: map[string]string{
+				"security.capability": "cap_data",
+			},
+		},
+		{
+			name:    "single user xattr",
+			entries: buildXattrEntry(xattrIndexUser, "mykey", []byte("myvalue")),
+			expected: map[string]string{
+				"user.mykey": "myvalue",
+			},
+		},
+		{
+			name:    "posix acl access (name_len=0)",
+			entries: buildXattrEntry(xattrIndexPosixACLAccess, "", []byte("acl_data")),
+			expected: map[string]string{
+				"system.posix_acl_access": "acl_data",
+			},
+		},
+		{
+			name:    "posix acl default (name_len=0)",
+			entries: buildXattrEntry(xattrIndexPosixACLDefault, "", []byte("acl_default")),
+			expected: map[string]string{
+				"system.posix_acl_default": "acl_default",
+			},
+		},
+		{
+			name:    "multiple entries",
+			entries: buildMultiXattrEntries(),
+			expected: map[string]string{
+				"user.key1":     "val1",
+				"trusted.key2":  "val2",
+				"security.key3": "val3",
+			},
+		},
+		{
+			name:    "name too long for buffer",
+			entries: buildTruncatedEntry(xattrIndexTrusted, 200),
+			wantErr: true,
+		},
+		{
+			name:    "ea_inode value returns error",
+			entries: buildEAInodeEntry(xattrIndexUser, "big", 42),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := tt.values
+			if values == nil {
+				values = tt.entries
+			}
+			result, err := parseXattrEntries(tt.entries, values)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected %d entries, got %d: %v", len(tt.expected), len(result), result)
+			}
+			for k, want := range tt.expected {
+				got, ok := result[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if string(got) != want {
+					t.Errorf("key %q: got %q, want %q", k, string(got), want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBlockXattrEntries(t *testing.T) {
+	blockSize := 4096
+	block := make([]byte, blockSize)
+
+	// Write xattr block header with valid magic.
+	binary.LittleEndian.PutUint32(block[0:4], xattrMagic)
+
+	// Write a single entry after the header.
+	name := "myattr"
+	nameLen := len(name)
+	entryStart := xattrHeaderSize
+	block[entryStart] = uint8(nameLen)
+	block[entryStart+1] = xattrIndexUser
+
+	// Place value at the end of the block.
+	value := []byte("hello")
+	valueOffset := blockSize - len(value)
+	binary.LittleEndian.PutUint16(block[entryStart+2:entryStart+4], uint16(valueOffset))
+	binary.LittleEndian.PutUint32(block[entryStart+4:entryStart+8], 0)
+	binary.LittleEndian.PutUint32(block[entryStart+8:entryStart+12], uint32(len(value)))
+	binary.LittleEndian.PutUint32(block[entryStart+12:entryStart+16], 0)
+	copy(block[entryStart+xattrEntrySize:], name)
+	copy(block[valueOffset:], value)
+
+	// Parse using the block layout: entries start after header, values relative to block start.
+	entryData := block[xattrHeaderSize:]
+	result, err := parseXattrEntries(entryData, block)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	got, ok := result["user.myattr"]
+	if !ok {
+		t.Fatal("missing key user.myattr")
+	}
+	if string(got) != "hello" {
+		t.Errorf("got %q, want %q", string(got), "hello")
+	}
+}
+
+// buildXattrEntry creates a byte slice containing a single xattr entry
+// where entries and values share the same buffer (ibody-style).
+func buildXattrEntry(nameIndex uint8, name string, value []byte) []byte {
+	nameLen := len(name)
+	entryLen := xattrEntrySize + nameLen
+	entryLenAligned := (entryLen + 3) &^ 3
+
+	// Ensure there's a zero terminator entry after the real entry.
+	minLen := entryLenAligned + xattrEntrySize
+	valueOffset := minLen
+	totalLen := valueOffset + len(value)
+	if totalLen < minLen {
+		totalLen = minLen
+	}
+
+	buf := make([]byte, totalLen)
+
+	buf[0] = uint8(nameLen)
+	buf[1] = nameIndex
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(valueOffset))
+	binary.LittleEndian.PutUint32(buf[4:8], 0)
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(len(value)))
+	binary.LittleEndian.PutUint32(buf[12:16], 0)
+	copy(buf[xattrEntrySize:xattrEntrySize+nameLen], name)
+
+	copy(buf[valueOffset:], value)
+
+	return buf
+}
+
+// buildMultiXattrEntries creates a buffer with three xattr entries.
+func buildMultiXattrEntries() []byte {
+	type entry struct {
+		index uint8
+		name  string
+		value []byte
+	}
+	entries := []entry{
+		{xattrIndexUser, "key1", []byte("val1")},
+		{xattrIndexTrusted, "key2", []byte("val2")},
+		{xattrIndexSecurity, "key3", []byte("val3")},
+	}
+
+	// First pass: calculate entry area size.
+	entryAreaSize := 0
+	for _, e := range entries {
+		entryAreaSize += (xattrEntrySize + len(e.name) + 3) &^ 3
+	}
+	entryAreaSize += xattrEntrySize // zero terminator
+
+	// Values follow the entry area.
+	valueAreaStart := entryAreaSize
+	totalValueSize := 0
+	for _, e := range entries {
+		totalValueSize += len(e.value)
+	}
+
+	buf := make([]byte, valueAreaStart+totalValueSize)
+	pos := 0
+	valuePos := valueAreaStart
+
+	for _, e := range entries {
+		nameLen := len(e.name)
+		buf[pos] = uint8(nameLen)
+		buf[pos+1] = e.index
+		binary.LittleEndian.PutUint16(buf[pos+2:pos+4], uint16(valuePos))
+		binary.LittleEndian.PutUint32(buf[pos+4:pos+8], 0)
+		binary.LittleEndian.PutUint32(buf[pos+8:pos+12], uint32(len(e.value)))
+		binary.LittleEndian.PutUint32(buf[pos+12:pos+16], 0)
+		copy(buf[pos+xattrEntrySize:], e.name)
+		copy(buf[valuePos:], e.value)
+		pos = (pos + xattrEntrySize + nameLen + 3) &^ 3
+		valuePos += len(e.value)
+	}
+
+	return buf
+}
+
+// buildTruncatedEntry creates an entry that claims a name longer than the buffer.
+func buildTruncatedEntry(nameIndex uint8, nameLen int) []byte {
+	buf := make([]byte, xattrEntrySize+4)
+	buf[0] = uint8(nameLen)
+	buf[1] = nameIndex
+	return buf
+}
+
+// buildEAInodeEntry creates an entry with a non-zero e_value_inum (EA inode).
+func buildEAInodeEntry(nameIndex uint8, name string, valueInum uint32) []byte {
+	nameLen := len(name)
+	entryLen := xattrEntrySize + nameLen
+	entryLenAligned := (entryLen + 3) &^ 3
+	buf := make([]byte, entryLenAligned+xattrEntrySize)
+
+	buf[0] = uint8(nameLen)
+	buf[1] = nameIndex
+	binary.LittleEndian.PutUint16(buf[2:4], 0)
+	binary.LittleEndian.PutUint32(buf[4:8], valueInum)
+	binary.LittleEndian.PutUint32(buf[8:12], 100) // some size
+	binary.LittleEndian.PutUint32(buf[12:16], 0)
+	copy(buf[xattrEntrySize:xattrEntrySize+nameLen], name)
+
+	return buf
+}
+
+func TestReadIbodyXattrs(t *testing.T) {
+	// buildInodeBytes constructs raw inode bytes with optional inline xattrs.
+	// extraIsize is placed at offset 128 (i_extra_isize field).
+	// xattrData (if non-nil) is placed right after the extra inode fields,
+	// prefixed with the xattr magic.
+	buildInodeBytes := func(inodeSize int, extraIsize uint16, xattrData []byte) []byte {
+		buf := make([]byte, inodeSize)
+		if inodeSize > int(ext2InodeSize)+2 {
+			binary.LittleEndian.PutUint16(buf[ext2InodeSize:ext2InodeSize+2], extraIsize)
+		}
+		if xattrData != nil {
+			xattrStart := int(ext2InodeSize) + int(extraIsize)
+			binary.LittleEndian.PutUint32(buf[xattrStart:xattrStart+4], xattrMagic)
+			copy(buf[xattrStart+4:], xattrData)
+		}
+		return buf
+	}
+
+	tests := []struct {
+		name      string
+		inodeSize uint16
+		inodeData []byte
+		expected  map[string]string
+	}{
+		{
+			name:      "inode size 128 has no ibody xattrs",
+			inodeSize: 128,
+			inodeData: make([]byte, 128),
+			expected:  nil,
+		},
+		{
+			name:      "no xattr magic returns nil",
+			inodeSize: 256,
+			inodeData: make([]byte, 256),
+			expected:  nil,
+		},
+		{
+			name:      "valid ibody xattr",
+			inodeSize: 256,
+			inodeData: buildInodeBytes(256, 32, buildXattrEntry(xattrIndexUser, "foo", []byte("bar"))),
+			expected: map[string]string{
+				"user.foo": "bar",
+			},
+		},
+		{
+			name:      "extraIsize fills entire inode leaving no room",
+			inodeSize: 256,
+			inodeData: buildInodeBytes(256, 256-128, nil),
+			expected:  nil,
+		},
+		{
+			name:      "multiple ibody xattrs",
+			inodeSize: 512,
+			inodeData: buildInodeBytes(512, 32, buildMultiXattrEntries()),
+			expected: map[string]string{
+				"user.key1":     "val1",
+				"trusted.key2":  "val2",
+				"security.key3": "val3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := &FileSystem{
+				superblock: &superblock{
+					inodeSize: tt.inodeSize,
+				},
+			}
+			result, err := fs.readIbodyXattrs(tt.inodeData)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expected == nil {
+				if result != nil {
+					t.Fatalf("expected nil, got %v", result)
+				}
+				return
+			}
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected %d entries, got %d: %v", len(tt.expected), len(result), result)
+			}
+			for k, want := range tt.expected {
+				got, ok := result[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if string(got) != want {
+					t.Errorf("key %q: got %q, want %q", k, string(got), want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- needs: https://github.com/diskfs/go-diskfs/pull/351

Add GetXattr(path) public method that reads both inline (ibody) and external block xattrs.

Support all standard name index prefixes (user, trusted, security, system, posix_acl).
 