### PR TITLE
Fix fat32 name matching issues

### DIFF
--- a/filesystem/fat32/directoryentry.go
+++ b/filesystem/fat32/directoryentry.go
@@ -52,10 +52,29 @@ func (de *directoryEntry) Info() (iofs.FileInfo, error) {
 	return FileInfo{
 		modTime:   de.modifyTime,
 		name:      de.filenameLong,
-		shortName: shortNameFromDirEntry(de),
+		shortName: de.fullShortName(),
 		size:      int64(de.fileSize),
 		isDir:     de.isSubdirectory,
 	}, nil
+}
+
+func (de *directoryEntry) nameMatches(name string) bool {
+	return strings.EqualFold(de.filenameLong, name) || strings.EqualFold(de.fullShortName(), name)
+}
+
+func (de *directoryEntry) fullShortName() string {
+	name := de.filenameShort
+	if de.lowercaseShortname {
+		name = strings.ToLower(name)
+	}
+	ext := de.fileExtension
+	if de.lowercaseExtension {
+		ext = strings.ToLower(ext)
+	}
+	if ext != "" {
+		return name + "." + ext
+	}
+	return name
 }
 
 func (de *directoryEntry) IsDir() bool {
@@ -73,7 +92,7 @@ func (de *directoryEntry) Name() string {
 	if de.filenameLong != "" {
 		return de.filenameLong
 	}
-	return shortNameFromDirEntry(de)
+	return de.fullShortName()
 }
 
 func (de *directoryEntry) toBytes() ([]byte, error) {

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -564,11 +564,7 @@ func (fs *FileSystem) Chtimes(p string, ctime, atime, mtime time.Time) error {
 	// find the specific entry we need
 	var entry *directoryEntry
 	for _, e := range entries {
-		shortName := e.filenameShort
-		if e.fileExtension != "" {
-			shortName += "." + e.fileExtension
-		}
-		if !strings.EqualFold(e.filenameLong, filename) && !strings.EqualFold(shortName, filename) {
+		if !e.nameMatches(filename) {
 			continue
 		}
 		entry = e
@@ -655,11 +651,7 @@ func (fs *FileSystem) OpenFile(p string, flag int) (filesystem.File, error) {
 		targetEntry = &parentDir.directoryEntry
 	} else {
 		for _, e := range entries {
-			shortName := e.filenameShort
-			if e.fileExtension != "" {
-				shortName += "." + e.fileExtension
-			}
-			if !strings.EqualFold(e.filenameLong, filename) && !strings.EqualFold(shortName, filename) {
+			if !e.nameMatches(filename) {
 				continue
 			}
 			// if we got this far, we have found the file
@@ -738,11 +730,7 @@ func (fs *FileSystem) Remove(pathname string) error {
 	// we now know that the directory exists, see if the file exists
 	var targetEntry *directoryEntry
 	for _, e := range entries {
-		shortName := e.filenameShort
-		if e.fileExtension != "" {
-			shortName += "." + e.fileExtension
-		}
-		if e.filenameLong != filename && shortName != filename {
+		if !e.nameMatches(filename) {
 			continue
 		}
 		// cannot do anything with directories
@@ -809,11 +797,7 @@ func (fs *FileSystem) Rename(oldpath, newpath string) error {
 	// we now know that the directory exists, see if the file exists
 	var targetEntry *directoryEntry
 	for _, e := range entries {
-		shortName := e.filenameShort
-		if e.fileExtension != "" {
-			shortName += "." + e.fileExtension
-		}
-		if e.filenameLong != filename && shortName != filename {
+		if !e.nameMatches(filename) {
 			continue
 		}
 		// if we got this far, we have found the file
@@ -1110,7 +1094,7 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, []*di
 			// match is determined by any one of:
 			// - long filename == provided name
 			// - uppercase(short filename) == uppercase(provided name)
-			if !strings.EqualFold(e.filenameLong, subp) && !strings.EqualFold(e.filenameShort, subp) {
+			if !e.nameMatches(subp) {
 				continue
 			}
 			if !e.isSubdirectory {

--- a/filesystem/fat32/file.go
+++ b/filesystem/fat32/file.go
@@ -27,7 +27,7 @@ func (fl *File) Stat() (iofs.FileInfo, error) {
 	return FileInfo{
 		modTime:   fl.modifyTime,
 		name:      fl.filenameLong,
-		shortName: shortNameFromDirEntry(fl.directoryEntry),
+		shortName: fl.fullShortName(),
 		size:      int64(fl.fileSize),
 		isDir:     fl.isSubdirectory,
 	}, nil

--- a/filesystem/fat32/fileinfo.go
+++ b/filesystem/fat32/fileinfo.go
@@ -1,9 +1,7 @@
 package fat32
 
 import (
-	"fmt"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -70,19 +68,4 @@ func (fi FileInfo) Size() int64 {
 //nolint:gocritic // we need this to comply with fs.FileInfo
 func (fi FileInfo) Sys() interface{} {
 	return nil
-}
-
-func shortNameFromDirEntry(e *directoryEntry) string {
-	shortName := e.filenameShort
-	if e.lowercaseShortname {
-		shortName = strings.ToLower(shortName)
-	}
-	fileExtension := e.fileExtension
-	if e.lowercaseExtension {
-		fileExtension = strings.ToLower(fileExtension)
-	}
-	if fileExtension != "" {
-		shortName = fmt.Sprintf("%s.%s", shortName, fileExtension)
-	}
-	return shortName
 }


### PR DESCRIPTION
### Issue 1
`.readDirWithMkdir()` was using `e.filenameShort` without extension, so if a directory had an extension, it would not match.

### Issue 2
`.Remove()` and `.Rename()` properly added the extension, but did not use case-insensitive name matching, which violates the spec.

In general, I found this pattern in more than 5 funcs, where some had it right, others missed different parts. I fixed all by cleaning up the abstractions and creating obvious `.nameMatches()` and `.fullShortName()` methods.