### PR TITLE
fix(iso9660): Open() now handles directories and implements fs.ReadDirFile

### DIFF
--- a/filesystem/iso9660/compatibility_test.go
+++ b/filesystem/iso9660/compatibility_test.go
@@ -1,6 +1,7 @@
 package iso9660
 
 import (
+	"io/fs"
 	"os"
 	"testing"
 
@@ -16,25 +17,25 @@ func TestFSCompatibility(t *testing.T) {
 	defer f.Close()
 
 	b := file.New(f, true)
-	fs, err := Read(b, 0, 0, 2048)
+	fsys, err := Read(b, 0, 0, 2048)
 	if err != nil {
 		t.Fatalf("iso read: %s", err)
 	}
 
-	if _, err := fs.ReadDir("/"); err == nil {
+	if _, err := fsys.ReadDir("/"); err == nil {
 		t.Fatalf("should have given error with ReadDir(/): %s", err)
 	}
-	entries, err := fs.ReadDir(".")
+	entries, err := fsys.ReadDir(".")
 	if err != nil {
 		t.Fatalf("should not have given error with ReadDir(.): %s", err)
 	}
 	if len(entries) != 5 {
 		t.Fatalf("should be 5 entries in iso fs")
 	}
-	if _, err := fs.Open("/README.MD"); err == nil {
+	if _, err := fsys.Open("/README.MD"); err == nil {
 		t.Fatalf("should have given an error with Open(/README.MD)")
 	}
-	testfile, err := fs.Open("README.MD")
+	testfile, err := fsys.Open("README.MD")
 	if err != nil {
 		t.Fatalf("test file: %s", err)
 	}
@@ -46,5 +47,208 @@ func TestFSCompatibility(t *testing.T) {
 		t.Fatalf("size bad: %d", stat.Size())
 	}
 
-	testutil.TestFSTree(t, fs)
+	testutil.TestFSTree(t, fsys)
+}
+
+func TestOpenRootDirectory(t *testing.T) {
+	f, err := os.Open(ISO9660File)
+	if err != nil {
+		t.Fatalf("Failed to read iso9660 testfile: %v", err)
+	}
+	defer f.Close()
+
+	b := file.New(f, true)
+	fsys, err := Read(b, 0, 0, 2048)
+	if err != nil {
+		t.Fatalf("iso read: %s", err)
+	}
+
+	// Open root directory
+	root, err := fsys.Open(".")
+	if err != nil {
+		t.Fatalf("Open(\".\") should succeed: %v", err)
+	}
+	defer root.Close()
+
+	// Should implement ReadDirFile
+	rdf, ok := root.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("Open(\".\") should return a ReadDirFile")
+	}
+
+	// Stat should return "." as name
+	info, err := root.Stat()
+	if err != nil {
+		t.Fatalf("Stat on root: %v", err)
+	}
+	if info.Name() != "." {
+		t.Fatalf("root Stat().Name() = %q, want \".\"", info.Name())
+	}
+	if !info.IsDir() {
+		t.Fatal("root Stat().IsDir() should be true")
+	}
+
+	// ReadDir should list entries
+	dirEntries, err := rdf.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("ReadDir(-1) on root: %v", err)
+	}
+	if len(dirEntries) != 5 {
+		t.Fatalf("expected 5 root entries, got %d", len(dirEntries))
+	}
+
+	// Read should return ErrInvalid
+	buf := make([]byte, 10)
+	if _, err := root.Read(buf); err != fs.ErrInvalid {
+		t.Fatalf("Read on directory should return fs.ErrInvalid, got %v", err)
+	}
+}
+
+func TestOpenSubdirectory(t *testing.T) {
+	f, err := os.Open(ISO9660File)
+	if err != nil {
+		t.Fatalf("Failed to read iso9660 testfile: %v", err)
+	}
+	defer f.Close()
+
+	b := file.New(f, true)
+	fsys, err := Read(b, 0, 0, 2048)
+	if err != nil {
+		t.Fatalf("iso read: %s", err)
+	}
+
+	// Open the FOO subdirectory
+	dir, err := fsys.Open("FOO")
+	if err != nil {
+		t.Fatalf("Open(\"FOO\") should succeed: %v", err)
+	}
+	defer dir.Close()
+
+	// Should implement ReadDirFile
+	rdf, ok := dir.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("Open(\"FOO\") should return a ReadDirFile")
+	}
+
+	// Stat should return directory info
+	info, err := dir.Stat()
+	if err != nil {
+		t.Fatalf("Stat on FOO: %v", err)
+	}
+	if info.Name() != "FOO" {
+		t.Fatalf("FOO Stat().Name() = %q, want \"FOO\"", info.Name())
+	}
+	if !info.IsDir() {
+		t.Fatal("FOO Stat().IsDir() should be true")
+	}
+
+	// ReadDir with cursor: read 3 at a time
+	first, err := rdf.ReadDir(3)
+	if err != nil {
+		t.Fatalf("ReadDir(3) first call: %v", err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("expected 3 entries from first ReadDir(3), got %d", len(first))
+	}
+
+	// Continue reading
+	rest, err := rdf.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("ReadDir(-1) after partial read: %v", err)
+	}
+	// FOO directory has 76 files (FILENA00..FILENA75)
+	totalEntries := len(first) + len(rest)
+	if totalEntries != 76 {
+		t.Fatalf("expected 76 total entries in FOO, got %d", totalEntries)
+	}
+}
+
+func TestStatRootDirectory(t *testing.T) {
+	f, err := os.Open(ISO9660File)
+	if err != nil {
+		t.Fatalf("Failed to read iso9660 testfile: %v", err)
+	}
+	defer f.Close()
+
+	b := file.New(f, true)
+	fsys, err := Read(b, 0, 0, 2048)
+	if err != nil {
+		t.Fatalf("iso read: %s", err)
+	}
+
+	info, err := fsys.Stat(".")
+	if err != nil {
+		t.Fatalf("Stat(\".\") should succeed: %v", err)
+	}
+	if info.Name() != "." {
+		t.Fatalf("Stat(\".\").Name() = %q, want \".\"", info.Name())
+	}
+	if !info.IsDir() {
+		t.Fatal("Stat(\".\").IsDir() should be true")
+	}
+}
+
+func TestOpenDirectoryRockRidge(t *testing.T) {
+	f, err := os.Open(RockRidgeFile)
+	if err != nil {
+		t.Fatalf("Failed to read rock ridge testfile: %v", err)
+	}
+	defer f.Close()
+
+	b := file.New(f, true)
+	fsys, err := Read(b, 0, 0, 2048)
+	if err != nil {
+		t.Fatalf("iso read: %s", err)
+	}
+
+	// Open root
+	root, err := fsys.Open(".")
+	if err != nil {
+		t.Fatalf("Open(\".\") should succeed: %v", err)
+	}
+	defer root.Close()
+
+	rdf, ok := root.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("Open(\".\") should return a ReadDirFile")
+	}
+
+	entries, err := rdf.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("ReadDir(-1) on root: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one entry in rock ridge root")
+	}
+
+	// Find the "foo" subdirectory (Rock Ridge uses lowercase)
+	found := false
+	for _, e := range entries {
+		if e.IsDir() && e.Name() == "foo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected to find 'foo' subdirectory in rock ridge root")
+	}
+
+	// Open the foo subdirectory
+	dir, err := fsys.Open("foo")
+	if err != nil {
+		t.Fatalf("Open(\"foo\") should succeed: %v", err)
+	}
+	defer dir.Close()
+
+	rdf2, ok := dir.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("Open(\"foo\") should return a ReadDirFile")
+	}
+	dirEntries, err := rdf2.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("ReadDir(-1) on foo: %v", err)
+	}
+	if len(dirEntries) == 0 {
+		t.Fatal("expected entries in rock ridge foo directory")
+	}
 }

--- a/filesystem/iso9660/dirfile.go
+++ b/filesystem/iso9660/dirfile.go
@@ -1,0 +1,90 @@
+package iso9660
+
+import (
+	"io"
+	iofs "io/fs"
+)
+
+// dirFile represents an opened directory in an iso9660 filesystem.
+// It implements fs.File and fs.ReadDirFile, allowing directory listing
+// via Open() as required by the fs.FS contract.
+type dirFile struct {
+	entry   *directoryEntry
+	fs      *FileSystem
+	path    string          // fs.FS-style path (e.g., "." or "boot/grub")
+	entries []iofs.DirEntry // lazily loaded
+	dirPos  int             // cursor for sequential ReadDir(n) calls
+	closed  bool
+}
+
+var _ iofs.File = (*dirFile)(nil)
+var _ iofs.ReadDirFile = (*dirFile)(nil)
+
+// Read on a directory always returns fs.ErrInvalid.
+func (df *dirFile) Read([]byte) (int, error) {
+	return 0, iofs.ErrInvalid
+}
+
+// Close marks the directory handle as closed.
+func (df *dirFile) Close() error {
+	df.closed = true
+	return nil
+}
+
+// Stat returns the FileInfo for this directory.
+func (df *dirFile) Stat() (iofs.FileInfo, error) {
+	if df.path == "." {
+		return rootDirInfo{df.entry}, nil
+	}
+	return df.entry, nil
+}
+
+// ReadDir reads the contents of the directory.
+// If n > 0, it returns at most n entries and advances the cursor.
+// If n <= 0, it returns all remaining entries.
+func (df *dirFile) ReadDir(n int) ([]iofs.DirEntry, error) {
+	// Lazy-load entries on first call
+	if df.entries == nil {
+		entries, err := df.fs.ReadDir(df.path)
+		if err != nil {
+			return nil, err
+		}
+		df.entries = entries
+	}
+
+	// All remaining entries
+	if n <= 0 {
+		if df.dirPos >= len(df.entries) {
+			return nil, nil
+		}
+		rest := df.entries[df.dirPos:]
+		df.dirPos = len(df.entries)
+		return rest, nil
+	}
+
+	// Up to n entries
+	if df.dirPos >= len(df.entries) {
+		return nil, io.EOF
+	}
+	end := df.dirPos + n
+	if end > len(df.entries) {
+		end = len(df.entries)
+	}
+	result := df.entries[df.dirPos:end]
+	df.dirPos = end
+
+	if df.dirPos >= len(df.entries) {
+		return result, io.EOF
+	}
+	return result, nil
+}
+
+// rootDirInfo wraps a directoryEntry to override Name() for the root directory.
+// The root directoryEntry has filename="" but fs.FileInfo requires Name() == ".".
+type rootDirInfo struct {
+	iofs.FileInfo
+}
+
+func (ri rootDirInfo) Name() string {
+	return "."
+}

--- a/filesystem/iso9660/iso9660.go
+++ b/filesystem/iso9660/iso9660.go
@@ -411,18 +411,53 @@ func (fsm *FileSystem) ReadDir(p string) ([]iofs.DirEntry, error) {
 	return de, nil
 }
 
-// Open returns an fs.File from which you can read the contents of a file
-// Especially useful for doing fs.FS operations
+// Open returns an fs.File for the named file or directory.
+// If the path refers to a directory, the returned file also implements
+// fs.ReadDirFile, allowing callers such as http.FileServer(http.FS(fs))
+// to list directory contents.
 func (fsm *FileSystem) Open(p string) (iofs.File, error) {
 	// should not accept anything that starts with /
 	if err := validatePath(p); err != nil {
 		return nil, err
 	}
-	file, err := fsm.OpenFile(p, os.O_RDONLY)
-	if err != nil {
-		return nil, err
+
+	// workspace mode: os.Open handles both files and directories
+	if fsm.workspace != "" {
+		return os.Open(path.Join(fsm.workspace, p))
 	}
-	return file, nil
+
+	// root directory
+	if p == "." {
+		return &dirFile{entry: fsm.rootDir, fs: fsm, path: "."}, nil
+	}
+
+	// look up the entry in its parent directory
+	dir := path.Dir(p)
+	filename := path.Base(p)
+	entries, err := fsm.readDirectory(dir)
+	if err != nil {
+		return nil, &iofs.PathError{Op: "open", Path: p, Err: err}
+	}
+
+	for _, e := range entries {
+		if e.isSelf || e.isParent {
+			continue
+		}
+		if e.Name() == filename {
+			if e.IsDir() {
+				return &dirFile{entry: e, fs: fsm, path: p}, nil
+			}
+			// regular file
+			return &File{
+				directoryEntry: e,
+				isReadWrite:    false,
+				isAppend:       false,
+				offset:         0,
+			}, nil
+		}
+	}
+
+	return nil, &iofs.PathError{Op: "open", Path: p, Err: iofs.ErrNotExist}
 }
 
 // OpenFile returns an io.ReadWriter from which you can read the contents of a file
@@ -521,6 +556,10 @@ func (fsm *FileSystem) Remove(p string) error {
 
 // Stat returns a FileInfo describing the file.
 func (fsm *FileSystem) Stat(name string) (iofs.FileInfo, error) {
+	// root directory
+	if name == "." {
+		return rootDirInfo{fsm.rootDir}, nil
+	}
 	dir := path.Dir(name)
 	basename := path.Base(name)
 	des, err := fsm.ReadDir(dir)


### PR DESCRIPTION
Fixes #356

### Changes:
1. **New file: `filesystem/iso9660/dirfile.go`**
   - `dirFile` struct — implements both `fs.File` and `fs.ReadDirFile` for directory handles.
   - `Read()` returns `fs.ErrInvalid` (directories aren't byte-readable).
   - `Close()` marks the handle as closed.
   - `Stat()` returns the directory entry's FileInfo; for root `.`, wraps with `rootDirInfo` to fix `Name()`.
   - `ReadDir(n)` — lazy-loads entries via `FileSystem.ReadDir()` and tracks a cursor for sequential calls, following the full `fs.ReadDirFile` contract.
   - `rootDirInfo` wrapper — overrides `Name()` to return `.` (the raw root `directoryEntry` has empty filename).

2. **Modified: `filesystem/iso9660/iso9660.go`**
   - `Open()` rewritten — no longer delegates to `OpenFile()`. Instead:
     - In workspace mode: calls `os.Open()` directly.
     - For `.`: returns `dirFile` wrapping `rootDir`.
     - For other paths: reads the parent directory entries, and returns either a `dirFile` (if directory) or a `File` (if regular file).
   - `OpenFile()` is unchanged — existing internal API preserved.
   - `Stat()` fixed — added special case for `.` to return root directory info.

3. **Modified: `filesystem/iso9660/compatibility_test.go`**
   - Added tests: `TestOpenRootDirectory`, `TestOpenSubdirectory`, `TestStatRootDirectory`, `TestOpenDirectoryRockRidge`.

### Test results
- [x] All existing tests pass
- [x] All new tests pass
- [x] Full project builds clean