### PR TITLE
squashfs: implemented chmod command

### DIFF
--- a/filesystem/squashfs/squashfs.go
+++ b/filesystem/squashfs/squashfs.go
@@ -320,11 +320,16 @@ func (fs *FileSystem) Symlink(oldpath, newpath string) error {
 
 // Chmod changes the mode of the named file to mode. If the file is a symbolic link,
 // it changes the mode of the link's target.
-//
-//nolint:revive // parameters will be used eventually
 func (fs *FileSystem) Chmod(name string, mode os.FileMode) error {
-	// https://dr-emann.github.io/squashfs/squashfs.html#_common_inode_header
-	return filesystem.ErrNotImplemented
+	if err := validatePath(name); err != nil {
+		return err
+	}
+
+	if fs.workspace == "" {
+		return filesystem.ErrReadonlyFilesystem
+	}
+
+	return os.Chmod(path.Join(fs.workspace, name), mode)
 }
 
 // Chown changes the numeric uid and gid of the named file. If the file is a symbolic link,


### PR DESCRIPTION
This PR implements the `Chmod` command in the squashfs file system.

It only changes the permissions if the filesystem wasn't finalized yet.