### PR TITLE
rfc: risky optimisations for ext4

### DIFF
--- a/filesystem/ext4/create_bench_test.go
+++ b/filesystem/ext4/create_bench_test.go
@@ -1,0 +1,188 @@
+package ext4
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/diskfs/go-diskfs/backend/file"
+)
+
+func checkE2fsck(t testing.TB) {
+	t.Helper()
+	if _, err := exec.LookPath("e2fsck"); err != nil {
+		t.Skip("e2fsck not available")
+	}
+}
+
+func checkMkfsExt4(t testing.TB) {
+	t.Helper()
+	if _, err := exec.LookPath("mkfs.ext4"); err != nil {
+		t.Skip("mkfs.ext4 not available")
+	}
+}
+
+func runE2fsck(t testing.TB, path string) {
+	t.Helper()
+	cmd := exec.Command("e2fsck", "-f", "-n", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("e2fsck failed: %v\nstdout:\n%s\nstderr:\n%s",
+			err, stdout.String(), stderr.String())
+	}
+}
+
+func benchmarkCreate(b *testing.B, size int64, params *Params) {
+	b.Helper()
+	for b.Loop() {
+		path := filepath.Join(b.TempDir(), "vol.img")
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0o600)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := f.Truncate(size); err != nil {
+			f.Close()
+			b.Fatal(err)
+		}
+		fs, err := Create(file.New(f, false), size, 0, 512, params)
+		if err != nil {
+			f.Close()
+			b.Fatal(err)
+		}
+		fs.Close()
+		f.Close()
+	}
+}
+
+// BenchmarkCreate20GB benchmarks creating a 20 GB sparse ext4 filesystem
+// with 4096-byte blocks and metadata checksums enabled.
+//
+// This is the default configuration used by containerd for writable
+// container layers. Run with:
+//
+//	go test -bench BenchmarkCreate20GB -run '^$' -benchmem ./filesystem/ext4/
+func BenchmarkCreate20GB(b *testing.B) {
+	benchmarkCreate(b, 20*1024*1024*1024, &Params{
+		SectorsPerBlock: 8, // 4096 byte blocks
+		Features: []FeatureOpt{
+			WithFeatureMetadataChecksums(true),
+			WithFeatureReservedGDTBlocksForExpansion(false),
+		},
+	})
+}
+
+// BenchmarkCreate20GBNoJournal is the same as BenchmarkCreate20GB but
+// without a journal. Run with:
+//
+//	go test -bench BenchmarkCreate20GBNoJournal -run '^$' -benchmem ./filesystem/ext4/
+func BenchmarkCreate20GBNoJournal(b *testing.B) {
+	benchmarkCreate(b, 20*1024*1024*1024, &Params{
+		SectorsPerBlock: 8,
+		Features: []FeatureOpt{
+			WithFeatureMetadataChecksums(true),
+			WithFeatureHasJournal(false),
+			WithFeatureReservedGDTBlocksForExpansion(false),
+		},
+	})
+}
+
+// BenchmarkCreate20GBMkfsExec benchmarks the external mkfs.ext4 binary with
+// lazy_itable_init and lazy_journal_init as a reference baseline. Skipped if
+// mkfs.ext4 is not on PATH. Run with:
+//
+//	PATH="/opt/homebrew/opt/e2fsprogs/sbin:$PATH" go test -bench BenchmarkCreate20GBMkfsExec -run '^$' -benchmem ./filesystem/ext4/
+func BenchmarkCreate20GBMkfsExec(b *testing.B) {
+	checkMkfsExt4(b)
+	for b.Loop() {
+		path := filepath.Join(b.TempDir(), "vol.img")
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0o600)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := f.Truncate(20 * 1024 * 1024 * 1024); err != nil {
+			f.Close()
+			b.Fatal(err)
+		}
+		f.Close()
+
+		cmd := exec.Command("mkfs.ext4", "-F", "-q",
+			"-E", "lazy_itable_init=1,lazy_journal_init=1",
+			path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			b.Fatalf("mkfs.ext4 failed: %v\n%s", err, out)
+		}
+	}
+}
+
+// TestCreateLazyInitE2fsck verifies that a filesystem created with metadata
+// checksums passes e2fsck validation at various sizes. Skipped if e2fsck is
+// not on PATH. Run with:
+//
+//	PATH="/opt/homebrew/opt/e2fsprogs/sbin:$PATH" go test -run TestCreateLazyInitE2fsck -v ./filesystem/ext4/
+func TestCreateLazyInitE2fsck(t *testing.T) {
+	checkE2fsck(t)
+
+	testcases := []struct {
+		name string
+		size int64
+		opts *Params
+	}{
+		{
+			name: "20GB with journal",
+			size: 20 * 1024 * 1024 * 1024,
+			opts: &Params{
+				SectorsPerBlock: 8,
+				Features: []FeatureOpt{
+					WithFeatureMetadataChecksums(true),
+					WithFeatureReservedGDTBlocksForExpansion(false),
+				},
+			},
+		},
+		{
+			name: "20GB no journal",
+			size: 20 * 1024 * 1024 * 1024,
+			opts: &Params{
+				SectorsPerBlock: 8,
+				Features: []FeatureOpt{
+					WithFeatureMetadataChecksums(true),
+					WithFeatureHasJournal(false),
+					WithFeatureReservedGDTBlocksForExpansion(false),
+				},
+			},
+		},
+		{
+			name: "512MB with journal",
+			size: 512 * 1024 * 1024,
+			opts: &Params{
+				SectorsPerBlock: 8,
+				Features: []FeatureOpt{
+					WithFeatureMetadataChecksums(true),
+					WithFeatureReservedGDTBlocksForExpansion(false),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			outfile, f := testCreateEmptyFile(t, tc.size)
+			defer f.Close()
+
+			fs, err := Create(file.New(f, false), tc.size, 0, 512, tc.opts)
+			if err != nil {
+				t.Fatalf("Create failed: %v", err)
+			}
+			fs.Close()
+
+			if err := f.Sync(); err != nil {
+				t.Fatalf("Sync failed: %v", err)
+			}
+
+			runE2fsck(t, outfile)
+		})
+	}
+}

--- a/filesystem/ext4/create_test.go
+++ b/filesystem/ext4/create_test.go
@@ -428,6 +428,43 @@ func TestCreateLargeFilesystem(t *testing.T) {
 	}
 }
 
+// TestCreateLargeFilesystemJournal verifies that creating a filesystem larger
+// than 4 GB produces a valid journal. This is a regression test: the journal
+// superblock maxLen was not recomputed after capping journalSize to 128 MB,
+// causing e2fsck to report "journal too short" on large filesystems.
+func TestCreateLargeFilesystemJournal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large filesystem test in short mode")
+	}
+	if _, err := exec.LookPath("e2fsck"); err != nil {
+		t.Skip("e2fsck not available")
+	}
+
+	// 5 GB is the smallest size that triggers the bug: blockCount/32
+	// exceeds journalMaxSize (128 MB) worth of blocks.
+	size := int64(5) * 1024 * MB
+	outfile, f := testCreateEmptyFile(t, size)
+	defer f.Close()
+	fs, err := Create(file.New(f, false), size, 0, 512, &Params{
+		SectorsPerBlock: 8, // 4096-byte blocks
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	fs.Close()
+	if err := f.Sync(); err != nil {
+		t.Fatalf("Error syncing: %v", err)
+	}
+	cmd := exec.Command("e2fsck", "-f", "-n", outfile)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("e2fsck failed: %v\nstdout:\n%s\nstderr:\n%s",
+			err, stdout.String(), stderr.String())
+	}
+}
+
 // TestCreateWithCustomReservedBlocks tests Create with a custom reserved blocks percent.
 func TestCreateWithCustomReservedBlocks(t *testing.T) {
 	_, f := testCreateEmptyFile(t, 100*MB)

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -2710,6 +2710,9 @@ func (fs *FileSystem) initJournal() error {
 	if journalSize < uint64(journalMinSize) {
 		journalSize = uint64(journalMinSize)
 	}
+	// Recompute journalBlocks after capping the size, so the journal
+	// superblock maxLen matches the number of blocks actually allocated.
+	journalBlocks = journalSize / uint64(fs.superblock.blockSize)
 
 	// Allocate the blocks for the journal
 	journalExtents, err := fs.allocateExtents(journalSize, nil)

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -2842,9 +2842,9 @@ func (fs *FileSystem) initJournal() error {
 	return nil
 }
 
-func setBitmapOrErr(bm *bitmap.Bitmap, location int, context string) error {
+func setBitmapOrErr(bm *bitmap.Bitmap, location int, format string, args ...any) error {
 	if err := bm.Set(location); err != nil {
-		return fmt.Errorf("%s: %w", context, err)
+		return fmt.Errorf(format+": %w", append(args, err)...)
 	}
 	return nil
 }
@@ -2884,7 +2884,7 @@ func (fs *FileSystem) buildBlockBitmapForGroup(i int, gd *groupDescriptor, group
 
 func (fs *FileSystem) markBlockBitmapPadding(blockBitmap *bitmap.Bitmap, groupIndex int, blocksInGroup uint64, blockBitmapSize int) error {
 	for j := int(blocksInGroup); j < blockBitmapSize; j++ {
-		if err := setBitmapOrErr(blockBitmap, j, fmt.Sprintf("group %d block bitmap padding", groupIndex)); err != nil {
+		if err := setBitmapOrErr(blockBitmap, j, "group %d block bitmap padding", groupIndex); err != nil {
 			return err
 		}
 	}
@@ -2911,7 +2911,7 @@ func (fs *FileSystem) markSuperBackupMetadata(blockBitmap *bitmap.Bitmap, groupI
 	}
 	// Mark superblock and GDT blocks as used
 	for j := uint64(0); j < metaBlocks; j++ {
-		if err := setBitmapOrErr(blockBitmap, int(j), fmt.Sprintf("group %d metadata", groupIndex)); err != nil {
+		if err := setBitmapOrErr(blockBitmap, int(j), "group %d metadata", groupIndex); err != nil {
 			return err
 		}
 	}
@@ -2933,7 +2933,7 @@ func (fs *FileSystem) markFlexMetadataBlocks(blockBitmap *bitmap.Bitmap, groupIn
 		if otherGd.blockBitmapLocation >= firstBlockOfGroup &&
 			otherGd.blockBitmapLocation < firstBlockOfGroup+uint64(fs.superblock.blocksPerGroup) {
 			blockOffset := otherGd.blockBitmapLocation - firstBlockOfGroup
-			if err := setBitmapOrErr(blockBitmap, int(blockOffset), fmt.Sprintf("group %d block bitmap", groupIndex)); err != nil {
+			if err := setBitmapOrErr(blockBitmap, int(blockOffset), "group %d block bitmap", groupIndex); err != nil {
 				return err
 			}
 		}
@@ -2942,7 +2942,7 @@ func (fs *FileSystem) markFlexMetadataBlocks(blockBitmap *bitmap.Bitmap, groupIn
 		if otherGd.inodeBitmapLocation >= firstBlockOfGroup &&
 			otherGd.inodeBitmapLocation < firstBlockOfGroup+uint64(fs.superblock.blocksPerGroup) {
 			blockOffset := otherGd.inodeBitmapLocation - firstBlockOfGroup
-			if err := setBitmapOrErr(blockBitmap, int(blockOffset), fmt.Sprintf("group %d inode bitmap", groupIndex)); err != nil {
+			if err := setBitmapOrErr(blockBitmap, int(blockOffset), "group %d inode bitmap", groupIndex); err != nil {
 				return err
 			}
 		}
@@ -2956,7 +2956,7 @@ func (fs *FileSystem) markFlexMetadataBlocks(blockBitmap *bitmap.Bitmap, groupIn
 		for block := inodeTableStart; block < inodeTableEnd; block++ {
 			if block >= firstBlockOfGroup && block < firstBlockOfGroup+uint64(fs.superblock.blocksPerGroup) {
 				blockOffset := block - firstBlockOfGroup
-				if err := setBitmapOrErr(blockBitmap, int(blockOffset), fmt.Sprintf("group %d inode table", groupIndex)); err != nil {
+				if err := setBitmapOrErr(blockBitmap, int(blockOffset), "group %d inode table", groupIndex); err != nil {
 					return err
 				}
 			}
@@ -2975,14 +2975,14 @@ func (fs *FileSystem) markNonFlexMetadataBlocks(blockBitmap *bitmap.Bitmap, grou
 
 	// Mark block bitmap block
 	if blockBitmapBlock < uint64(fs.superblock.blocksPerGroup) {
-		if err := setBitmapOrErr(blockBitmap, int(blockBitmapBlock), fmt.Sprintf("group %d block bitmap", groupIndex)); err != nil {
+		if err := setBitmapOrErr(blockBitmap, int(blockBitmapBlock), "group %d block bitmap", groupIndex); err != nil {
 			return err
 		}
 	}
 
 	// Mark inode bitmap block
 	if inodeBitmapBlock < uint64(fs.superblock.blocksPerGroup) {
-		if err := setBitmapOrErr(blockBitmap, int(inodeBitmapBlock), fmt.Sprintf("group %d inode bitmap", groupIndex)); err != nil {
+		if err := setBitmapOrErr(blockBitmap, int(inodeBitmapBlock), "group %d inode bitmap", groupIndex); err != nil {
 			return err
 		}
 	}
@@ -2991,7 +2991,7 @@ func (fs *FileSystem) markNonFlexMetadataBlocks(blockBitmap *bitmap.Bitmap, grou
 	inodeTableBlocks := groupDescriptorInodeTableBlocks(groupIndex, fs.superblock)
 	for j := uint64(0); j < inodeTableBlocks; j++ {
 		if inodeTableBlock+j < uint64(fs.superblock.blocksPerGroup) {
-			if err := setBitmapOrErr(blockBitmap, int(inodeTableBlock+j), fmt.Sprintf("group %d inode table", groupIndex)); err != nil {
+			if err := setBitmapOrErr(blockBitmap, int(inodeTableBlock+j), "group %d inode table", groupIndex); err != nil {
 				return err
 			}
 		}
@@ -3010,7 +3010,7 @@ func (fs *FileSystem) buildInodeBitmapForGroup(i int) (*bitmap.Bitmap, error) {
 	inodeBitmap := bitmap.NewBits(inodeBitmapSize)
 	// set 1 padding on anything past inodesPerGroup
 	for j := int(fs.superblock.inodesPerGroup); j < inodeBitmapSize; j++ {
-		if err := setBitmapOrErr(inodeBitmap, j, fmt.Sprintf("group %d inode bitmap padding", i)); err != nil {
+		if err := setBitmapOrErr(inodeBitmap, j, "group %d inode bitmap padding", i); err != nil {
 			return nil, err
 		}
 	}
@@ -3021,7 +3021,7 @@ func (fs *FileSystem) buildInodeBitmapForGroup(i int) (*bitmap.Bitmap, error) {
 		// Note: lostFoundInode (11) is NOT reserved, it's created as a directory
 		for j := 1; j < int(firstNonReservedInode); j++ {
 			if j < int(fs.superblock.inodesPerGroup) {
-				if err := setBitmapOrErr(inodeBitmap, j-1, fmt.Sprintf("group %d reserved inode %d", i, j)); err != nil {
+				if err := setBitmapOrErr(inodeBitmap, j-1, "group %d reserved inode %d", i, j); err != nil {
 					return nil, err
 				}
 			}

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -2792,24 +2792,10 @@ func (fs *FileSystem) initJournal() error {
 			return fmt.Errorf("wrote %d bytes of journal superblock instead of expected %d", n, len(journalSuperblockBytes))
 		}
 
-		// Zero out the rest of the journal blocks to ensure they're empty
-		// Start from the block after the superblock
-		remainingOffset := journalOffset + int64(JournalSuperblockSize)
-		remainingSize := int64(journalSize) - int64(JournalSuperblockSize)
-
-		if remainingSize > 0 {
-			// Write in chunks to avoid allocating too much memory at once
-			chunkSize := 1024 * 1024 // 1MB chunks
-			zeros := make([]byte, min(chunkSize, int(remainingSize)))
-			for written := int64(0); written < remainingSize; {
-				toWrite := min(len(zeros), int(remainingSize-written))
-				n, err := writable.WriteAt(zeros[:toWrite], remainingOffset+written)
-				if err != nil {
-					return fmt.Errorf("could not zero journal blocks: %w", err)
-				}
-				written += int64(n)
-			}
-		}
+		// The remaining journal blocks must be zero. For freshly-created
+		// or truncated files (the common case for Create), the backing
+		// storage is already zero, so we skip the explicit zero-fill.
+		// This avoids writing up to 128 MB of zeros via pwrite.
 	}
 
 	// Store journal backup in superblock

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -726,13 +726,6 @@ func Create(b backend.Storage, size, start, sectorsize int64, p *Params) (*FileS
 		return nil, fmt.Errorf("unable to initialize group descriptor tables: %w", err)
 	}
 
-	// Sync the underlying file to ensure all writes are persisted
-	if osFile, err := fsBackend.Sys(); err == nil && osFile != nil {
-		if err := osFile.Sync(); err != nil {
-			return nil, fmt.Errorf("error syncing file: %v", err)
-		}
-	}
-
 	// write the superblock and GDT to the various locations on disk
 	if err := fs.writeSuperblock(); err != nil {
 		return nil, fmt.Errorf("error writing Superblock: %v", err)

--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -690,7 +690,13 @@ func Create(b backend.Storage, size, start, sectorsize int64, p *Params) (*FileS
 		logGroupsPerFlex:             uint64(1 << logGroupsPerFlex),
 	}
 
-	gdt := buildGroupDescriptorsFromSuperblock(&sb)
+	// When checksums are enabled (metadata_csum or gdt_csum), non-zero
+	// block groups can be marked uninitialised. The kernel lazily
+	// initialises inode tables and bitmaps on first use, verified by the
+	// group descriptor checksums. This avoids writing hundreds of MB of
+	// zeros for inode tables during Create.
+	lazyInit := sb.gdtChecksumType() != gdtChecksumNone
+	gdt := buildGroupDescriptorsFromSuperblock(&sb, lazyInit)
 	// Make SubStorage Backend
 	fsBackend := backend.Sub(b, start, size)
 	fs := &FileSystem{
@@ -768,7 +774,12 @@ func Create(b backend.Storage, size, start, sectorsize int64, p *Params) (*FileS
 	if err := fs.writeSuperblock(); err != nil {
 		return nil, fmt.Errorf("error writing Superblock: %v", err)
 	}
-	// there is nothing in there
+	// Re-write GDT so that any group descriptor flags changed during
+	// journal/inode allocation (e.g. lazy bitmap initialisation) are
+	// persisted to disk.
+	if err := fs.writeGDT(); err != nil {
+		return nil, fmt.Errorf("error writing final GDT: %v", err)
+	}
 	return fs, nil
 }
 
@@ -2482,7 +2493,24 @@ func (fs *FileSystem) readBlockBitmap(group int) (*bitmap.Bitmap, error) {
 	if group >= len(fs.groupDescriptors.descriptors) {
 		return nil, fmt.Errorf("block group %d does not exist", group)
 	}
-	gd := fs.groupDescriptors.descriptors[group]
+	gd := &fs.groupDescriptors.descriptors[group]
+
+	// Lazily initialise uninitialised block bitmaps on first read.
+	// Build the correct bitmap (with metadata blocks marked used),
+	// write it to disk, and clear the uninit flag.
+	if gd.flags.blockBitmapUninitialized {
+		groupCount := fs.superblock.blockGroupCount()
+		bm, err := fs.buildBlockBitmapForGroup(group, gd, groupCount)
+		if err != nil {
+			return nil, fmt.Errorf("could not build block bitmap for uninit group %d: %w", group, err)
+		}
+		if err := fs.writeBlockBitmap(bm, group); err != nil {
+			return nil, fmt.Errorf("could not write block bitmap for uninit group %d: %w", group, err)
+		}
+		gd.flags.blockBitmapUninitialized = false
+		return bm, nil
+	}
+
 	bitmapLocation := gd.blockBitmapLocation
 	b := make([]byte, fs.superblock.blockSize)
 	offset := int64(bitmapLocation * uint64(fs.superblock.blockSize))
@@ -3008,54 +3036,67 @@ func (fs *FileSystem) initGroupDescriptorTables() error {
 	if err != nil {
 		return err
 	}
-	// Initialize and write bitmaps and inode tables for each block group
+	// Initialize and write bitmaps and inode tables for each block group.
+	// Groups marked as fully uninitialised are skipped — the kernel
+	// initialises them lazily on first use.
 	groupCount := fs.superblock.blockGroupCount()
 	for i := range fs.groupDescriptors.descriptors {
 		gd := &fs.groupDescriptors.descriptors[i]
-		blockBitmap, err := fs.buildBlockBitmapForGroup(i, gd, groupCount)
-		if err != nil {
-			return err
-		}
-		inodeBitmap, err := fs.buildInodeBitmapForGroup(i)
-		if err != nil {
-			return err
+
+		if gd.flags.blockBitmapUninitialized && gd.flags.inodesUninitialized {
+			continue
 		}
 
 		// Write block bitmap
-		blockBitmapBytes := blockBitmap.ToBytes()
-		blockBitmapOffset := int64(gd.blockBitmapLocation * uint64(fs.superblock.blockSize))
-		count, err := writable.WriteAt(blockBitmapBytes, blockBitmapOffset)
-		if err != nil {
-			return fmt.Errorf("error writing block bitmap for group %d: %v", i, err)
+		if !gd.flags.blockBitmapUninitialized {
+			blockBitmap, err := fs.buildBlockBitmapForGroup(i, gd, groupCount)
+			if err != nil {
+				return err
+			}
+			blockBitmapBytes := blockBitmap.ToBytes()
+			blockBitmapOffset := int64(gd.blockBitmapLocation * uint64(fs.superblock.blockSize))
+			count, err := writable.WriteAt(blockBitmapBytes, blockBitmapOffset)
+			if err != nil {
+				return fmt.Errorf("error writing block bitmap for group %d: %v", i, err)
+			}
+			if count != len(blockBitmapBytes) {
+				return fmt.Errorf("wrote %d bytes of block bitmap for group %d instead of expected %d", count, i, len(blockBitmapBytes))
+			}
+			gd.blockBitmapChecksum = bitmapChecksum(blockBitmapBytes, fs.superblock.checksumSeed)
 		}
-		if count != len(blockBitmapBytes) {
-			return fmt.Errorf("wrote %d bytes of block bitmap for group %d instead of expected %d", count, i, len(blockBitmapBytes))
-		}
-		gd.blockBitmapChecksum = bitmapChecksum(blockBitmapBytes, fs.superblock.checksumSeed)
 
 		// Write inode bitmap
-		inodeBitmapBytes := inodeBitmap.ToBytes()
-		inodeBitmapOffset := int64(gd.inodeBitmapLocation * uint64(fs.superblock.blockSize))
-		count, err = writable.WriteAt(inodeBitmapBytes, inodeBitmapOffset)
-		if err != nil {
-			return fmt.Errorf("error writing inode bitmap for group %d: %v", i, err)
+		if !gd.flags.inodesUninitialized {
+			inodeBitmap, err := fs.buildInodeBitmapForGroup(i)
+			if err != nil {
+				return err
+			}
+			inodeBitmapBytes := inodeBitmap.ToBytes()
+			inodeBitmapOffset := int64(gd.inodeBitmapLocation * uint64(fs.superblock.blockSize))
+			count, err := writable.WriteAt(inodeBitmapBytes, inodeBitmapOffset)
+			if err != nil {
+				return fmt.Errorf("error writing inode bitmap for group %d: %v", i, err)
+			}
+			if count != len(inodeBitmapBytes) {
+				return fmt.Errorf("wrote %d bytes of inode bitmap for group %d instead of expected %d", count, i, len(inodeBitmapBytes))
+			}
+			gd.inodeBitmapChecksum = bitmapChecksum(inodeBitmapBytes[:fs.superblock.inodesPerGroup/8], fs.superblock.checksumSeed)
 		}
-		if count != len(inodeBitmapBytes) {
-			return fmt.Errorf("wrote %d bytes of inode bitmap for group %d instead of expected %d", count, i, len(inodeBitmapBytes))
-		}
-		gd.inodeBitmapChecksum = bitmapChecksum(inodeBitmapBytes[:fs.superblock.inodesPerGroup/8], fs.superblock.checksumSeed)
 
-		// Initialize inode table - zero it out
-		inodeTableBlocks := groupDescriptorInodeTableBlocks(i, fs.superblock)
-		inodeTableSize := int(inodeTableBlocks * uint64(fs.superblock.blockSize))
-		inodeTableBytes := make([]byte, inodeTableSize)
-		inodeTableOffset := int64(gd.inodeTableLocation * uint64(fs.superblock.blockSize))
-		count, err = writable.WriteAt(inodeTableBytes, inodeTableOffset)
-		if err != nil {
-			return fmt.Errorf("error writing inode table for group %d: %v", i, err)
-		}
-		if count != inodeTableSize {
-			return fmt.Errorf("wrote %d bytes of inode table for group %d instead of expected %d", count, i, inodeTableSize)
+		// Write inode table — skip when the group has uninitialised
+		// inodes; the kernel zeroes the table on first use.
+		if !gd.flags.inodesUninitialized {
+			inodeTableBlocks := groupDescriptorInodeTableBlocks(i, fs.superblock)
+			inodeTableSize := int(inodeTableBlocks * uint64(fs.superblock.blockSize))
+			inodeTableBytes := make([]byte, inodeTableSize)
+			inodeTableOffset := int64(gd.inodeTableLocation * uint64(fs.superblock.blockSize))
+			count, err := writable.WriteAt(inodeTableBytes, inodeTableOffset)
+			if err != nil {
+				return fmt.Errorf("error writing inode table for group %d: %v", i, err)
+			}
+			if count != inodeTableSize {
+				return fmt.Errorf("wrote %d bytes of inode table for group %d instead of expected %d", count, i, inodeTableSize)
+			}
 		}
 	}
 	return nil
@@ -3232,7 +3273,7 @@ func blockGroupForBlock(blockNumber int, blocksPerGroup uint32) int {
 }
 
 // given the superblock, build the group descriptors
-func buildGroupDescriptorsFromSuperblock(sb *superblock) groupDescriptors {
+func buildGroupDescriptorsFromSuperblock(sb *superblock, lazyInit bool) groupDescriptors {
 	blocksPerGroup := uint64(sb.blocksPerGroup)
 	inodesPerGroup := sb.inodesPerGroup
 	inodeTableBlocks := (uint64(inodesPerGroup)*uint64(sb.inodeSize) + uint64(sb.blockSize) - 1) / uint64(sb.blockSize)
@@ -3346,8 +3387,26 @@ func buildGroupDescriptorsFromSuperblock(sb *superblock) groupDescriptors {
 		d.freeBlocks = uint32(blocksInGroup - overhead)
 		d.freeInodes = inodesPerGroup
 		d.usedDirectories = 0
-		d.flags = blockGroupFlags{}
-		d.unusedInodes = 0
+		// With lazy init (requires checksums), skip writing inode tables
+		// and bitmaps that the kernel will initialise on demand.
+		//
+		// INODE_UNINIT: safe for all groups except group 0 (which holds
+		// the root directory and reserved inodes).
+		//
+		// BLOCK_BITMAP_UNINIT: safe only when the group has no metadata
+		// overhead and is not the last (possibly partial) group.
+		if lazyInit && g > 0 {
+			d.flags.inodesUninitialized = true
+			d.unusedInodes = inodesPerGroup
+			if g < groups-1 && overhead == 0 {
+				d.flags.blockBitmapUninitialized = true
+			} else {
+				d.flags.inodeTableZeroed = true
+			}
+		} else {
+			d.flags = blockGroupFlags{inodeTableZeroed: true}
+			d.unusedInodes = 0
+		}
 		d.blockBitmapChecksum = 0
 		d.inodeBitmapChecksum = 0
 		d.snapshotExclusionBitmapLocation = 0


### PR DESCRIPTION
(Warning: lots of AI, risky patches, just an early prototype!)

I'd like to see how fast we can make ext4 `Create`: can we make it as quick as `mkfs.ext4`?

On top of #365 (a bug fix) and #366 (a benchmark), here are some possibilities:.

- on Mac, the `Sync()` call is very expensive because it calls [F_FULLSYNC](https://man.freebsd.org/cgi/man.cgi?query=fsync&manpath=Darwin+8.0.1%2Fppc) which is really slow because it pushes data to the physical storage. It's the only way to guarantee consistency over a macOS crash or power cut, but for many use-cases (such as writing an empty file?) we could push the policy to the caller who can call `Sync()` themselves if they need the consistency. This was expensive so I tried removing it:

```
      BenchmarkCreate20GB          484ms → 323ms  (-33%)
      BenchmarkCreate20GBMkfsExec             11ms (reference)
```

- If calling `Create` on a new sparse file (that's full of zeroes), there's no need to explicitly write zeroes into the journal, so I tried removing that:

```
      BenchmarkCreate20GB          323ms → 295ms  (-9%)
      BenchmarkCreate20GBMkfsExec             11ms (reference)
```

- switch to lazy initialisation (mark block groups as uninitialised, allow the kernel to initialise later)

```
      BenchmarkCreate20GB          295ms →  22ms  (-93%)   9MB  182K allocs
      BenchmarkCreate20GBMkfsExec             11ms (reference)
```

- reduce number of `fmt.Sprintf` calls in a hot path

```
      BenchmarkCreate20GB          22ms →  13ms  (-42%)   4.9MB  1.9K allocs
      BenchmarkCreate20GBMkfsExec            11ms (reference)
```

After all that it's basically as fast as `mkfs.ext4`!

I generated this by asking Claude to run the benchmark and investigate. I told it that
- `Sync` is expensive on Mac
- to instrument the code to see what's being written; reducing the number of writes made it faster (obviously)

It's not clear to me that assumptions about the file being zero are true in all use-cases. They should be for `mkfs.ext4` on a fresh file (e.g. the rwlayer case for containerd + nerdbox). Let me know what you think about that!