### PR TITLE
squashfs: fix inode block references when metadata is compressed (#360)

### DIFF
--- a/filesystem/squashfs/finalize.go
+++ b/filesystem/squashfs/finalize.go
@@ -1461,7 +1461,7 @@ func updateInodeLocations(files []*finalizeFileInfo) {
 // translateInodeLocations walks every inode location and every directory entry
 // and replaces its logical block index with the actual byte offset of that
 // metadata block in the inode table, using the offsets recorded by writeInodes.
-func translateInodeLocations(files []*finalizeFileInfo, directories []*finalizeFileInfo, blockOffsets []int64) {
+func translateInodeLocations(files, directories []*finalizeFileInfo, blockOffsets []int64) {
 	translate := func(logical uint32) uint32 {
 		if int(logical) >= len(blockOffsets) {
 			// should not happen, but be defensive — keep the value rather than panic

--- a/filesystem/squashfs/finalize.go
+++ b/filesystem/squashfs/finalize.go
@@ -222,12 +222,20 @@ func (fs *FileSystem) Finalize(options FinalizeOptions) error {
 		return fmt.Errorf("error updating inodes with final directory data: %v", err)
 	}
 
-	// write the inodes to the file
-	inodesWritten, inodeTableLocation, err := writeInodes(fileList, f, compressor, location)
+	// write the inodes to the file. writeInodes returns the byte offset (relative
+	// to the inode table start) of each metadata block it wrote, so we can fix up
+	// the logical block indices in inodeLocations and directory entries before
+	// writing the directory table.
+	inodesWritten, inodeTableLocation, inodeBlockOffsets, err := writeInodes(fileList, f, compressor, location)
 	if err != nil {
 		return fmt.Errorf("error writing inode data blocks: %v", err)
 	}
 	location += int64(inodesWritten)
+
+	// translate logical block indices into real on-disk byte offsets now that
+	// the actual compressed sizes are known. See updateInodeLocations for why
+	// this is needed — issue #360.
+	translateInodeLocations(fileList, directories, inodeBlockOffsets)
 
 	// write directory data
 	dirsWritten, dirTableLocation, err := writeDirectories(directories, f, compressor, location)
@@ -698,37 +706,42 @@ func writeFragmentBlocks(fileList []*finalizeFileInfo, f backend.WritableFile, w
 	return fragmentBlocks, allWritten, nil
 }
 
-func writeInodes(files []*finalizeFileInfo, f backend.WritableFile, compressor Compressor, location int64) (inodesWritten int, finalLocation uint64, err error) {
+// writeInodes writes the inode metadata table and returns the on-disk byte
+// offset (relative to inodeTableStart) of each metadata block, so callers can
+// translate logical block indices into real byte offsets.
+func writeInodes(files []*finalizeFileInfo, f backend.WritableFile, compressor Compressor, location int64) (inodesWritten int, finalLocation uint64, blockOffsets []int64, err error) {
 	var (
 		buf             []byte
 		maxSize         = int(metadataBlockSize)
 		initialLocation = location
 	)
+	// blockOffsets[i] is the byte offset (from inode table start) of logical
+	// metadata block i. Block 0 always starts at offset 0.
+	blockOffsets = []int64{0}
 	for _, e := range files {
 		// keep writing until we run out, or we hit 8KB
 		buf = append(buf, e.inode.toBytes()...)
 		if len(buf) > maxSize {
 			written, err := writeMetadataBlock(buf[:maxSize], f, compressor, location)
 			if err != nil {
-				return inodesWritten, 0, err
+				return inodesWritten, 0, nil, err
 			}
-			// count all we have written
 			inodesWritten += written
-			// increment for next write
 			location += int64(written)
-			// truncate all except what we wrote
 			buf = buf[maxSize:]
+			// record the byte offset where the NEXT metadata block starts
+			blockOffsets = append(blockOffsets, int64(inodesWritten))
 		}
 	}
 	// was there anything left?
 	if len(buf) > 0 {
 		written, err := writeMetadataBlock(buf, f, compressor, location)
 		if err != nil {
-			return inodesWritten, 0, err
+			return inodesWritten, 0, nil, err
 		}
 		inodesWritten += written
 	}
-	return inodesWritten, uint64(initialLocation), nil
+	return inodesWritten, uint64(initialLocation), blockOffsets, nil
 }
 
 // writeDirectories write all directories out to disk. Assumes it already has been optimized.
@@ -1423,22 +1436,49 @@ func createDirectories(e *finalizeFileInfo) []*finalizeFileInfo {
 	return dirs
 }
 
-// updateInodeLocations update each inode with where it will be on disk
-// i.e. the inode block, and the offset into the block
+// updateInodeLocations assigns each inode a logical metadata-block index plus an
+// offset within that block. The `block` field here is a LOGICAL INDEX (0, 1, 2…),
+// not a byte offset. After writeInodes actually writes and compresses each block,
+// translateInodeLocations converts these indices into on-disk byte offsets.
+//
+// Why: with compression enabled, compressed block sizes vary, so the on-disk
+// offset of metadata block N is not N * (metadataBlockSize + 2). The old code
+// pre-computed a fake byte offset from the logical index and it was wrong
+// whenever compression actually reduced block size — see issue #360.
 func updateInodeLocations(files []*finalizeFileInfo) {
 	var pos int64
-
-	// get block position for each inode
 	for _, f := range files {
 		b := f.inode.toBytes()
-		block, offset := uint32(pos/metadataBlockSize), uint16(pos%metadataBlockSize)
-		blockPos := block * (standardMetadataBlocksize + 2)
 		f.inodeLocation = blockPosition{
-			block:  blockPos,
-			offset: offset,
+			block:  uint32(pos / metadataBlockSize),
+			offset: uint16(pos % metadataBlockSize),
 			size:   len(b),
 		}
 		pos += int64(len(b))
+	}
+}
+
+// translateInodeLocations walks every inode location and every directory entry
+// and replaces its logical block index with the actual byte offset of that
+// metadata block in the inode table, using the offsets recorded by writeInodes.
+func translateInodeLocations(files []*finalizeFileInfo, directories []*finalizeFileInfo, blockOffsets []int64) {
+	translate := func(logical uint32) uint32 {
+		if int(logical) >= len(blockOffsets) {
+			// should not happen, but be defensive — keep the value rather than panic
+			return logical
+		}
+		return uint32(blockOffsets[logical])
+	}
+	for _, f := range files {
+		f.inodeLocation.block = translate(f.inodeLocation.block)
+	}
+	for _, d := range directories {
+		if d.directory == nil {
+			continue
+		}
+		for _, e := range d.directory.entries {
+			e.startBlock = translate(e.startBlock)
+		}
 	}
 }
 

--- a/filesystem/squashfs/finalize_issue360_test.go
+++ b/filesystem/squashfs/finalize_issue360_test.go
@@ -50,7 +50,7 @@ func TestFinalizeInodesAcrossMetadataBlocks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("OpenFile %s: %v", name, err)
 		}
-		if _, err := fh.Write([]byte(fmt.Sprintf("file %d content\n", i))); err != nil {
+		if _, err := fmt.Fprintf(fh, "file %d content\n", i); err != nil {
 			t.Fatalf("Write %s: %v", name, err)
 		}
 		fh.Close()

--- a/filesystem/squashfs/finalize_issue360_test.go
+++ b/filesystem/squashfs/finalize_issue360_test.go
@@ -1,0 +1,100 @@
+package squashfs_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/filesystem/squashfs"
+)
+
+// TestFinalizeInodesAcrossMetadataBlocks demonstrates the root cause of
+// https://github.com/diskfs/go-diskfs/issues/360.
+//
+// When compressed inode metadata spans multiple metadata blocks,
+// updateInodeLocations (finalize.go) computes each inode's block byte offset
+// as `logicalBlock * (metadataBlockSize + 2)` = `logicalBlock * 8194`.
+// That assumes every compressed metadata block is exactly 8194 bytes on disk,
+// which is only true when compression is effectively off. With real gzip
+// compression the blocks are typically much smaller, so directory entries
+// and the superblock root-inode ref point past the real block positions.
+// Readers then fail with "could not read directory entries" or
+// "failed to read inode X:Y" for every inode that isn't in block 0.
+//
+// Reproducer: enough small files (~600) to push inodes past the 8 KB
+// metadata-block boundary, plus CompressionLevel: 9 so gzip actually
+// reduces block size. (The default CompressorGzip{} uses level 0 = no
+// compression, which is why existing tests don't catch this.)
+//
+// Expected current behaviour: this test FAILS. Every file lookup returns
+// an error because even the root directory inode is past block 0.
+// After the fix in finalize.go, this test passes.
+func TestFinalizeInodesAcrossMetadataBlocks(t *testing.T) {
+	f, err := os.CreateTemp("", "squashfs_issue360_*.sqs")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(f.Name())
+
+	b := file.New(f, false)
+	fs, err := squashfs.Create(b, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	const numFiles = 600
+	for i := 0; i < numFiles; i++ {
+		name := fmt.Sprintf("f%04d.txt", i)
+		fh, err := fs.OpenFile(name, os.O_CREATE|os.O_RDWR)
+		if err != nil {
+			t.Fatalf("OpenFile %s: %v", name, err)
+		}
+		if _, err := fh.Write([]byte(fmt.Sprintf("file %d content\n", i))); err != nil {
+			t.Fatalf("Write %s: %v", name, err)
+		}
+		fh.Close()
+	}
+
+	// CompressionLevel 9 guarantees gzip actually compresses — default 0 means
+	// zlib.NoCompression and the bug doesn't reproduce.
+	if err := fs.Finalize(squashfs.FinalizeOptions{
+		Compression: &squashfs.CompressorGzip{CompressionLevel: 9},
+	}); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	fs2, err := squashfs.Read(b, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	failed := 0
+	firstFail := -1
+	for i := 0; i < numFiles; i++ {
+		name := fmt.Sprintf("f%04d.txt", i)
+		fh, err := fs2.OpenFile(name, os.O_RDONLY)
+		if err != nil {
+			if firstFail < 0 {
+				firstFail = i
+				t.Logf("FIRST FAIL at i=%d: OpenFile: %v", i, err)
+			}
+			failed++
+			continue
+		}
+		buf := make([]byte, 100)
+		n, _ := fh.Read(buf)
+		want := fmt.Sprintf("file %d content\n", i)
+		if string(buf[:n]) != want {
+			if firstFail < 0 {
+				firstFail = i
+				t.Logf("FIRST FAIL at i=%d: got %q want %q", i, buf[:n], want)
+			}
+			failed++
+		}
+		fh.Close()
+	}
+	if failed > 0 {
+		t.Errorf("%d of %d files failed (first failure at index %d)", failed, numFiles, firstFail)
+	}
+}


### PR DESCRIPTION
updateInodeLocations pre-computed each inode's metadata-block byte offset as `logicalBlock * (metadataBlockSize + 2)` = `logicalBlock * 8194`, which assumes every compressed metadata block is exactly 8194 bytes on disk. That's only true when compression is effectively off. With real gzip compression metadata blocks are typically much smaller, so directory entries and the superblock root-inode ref pointed past the real block positions. Readers then failed with "could not read directory entries" or "failed to read inode X:Y" for every file whose inode was not in block 0.

The bug reproduces without any "large" file — it just needs enough inodes to span a metadata block boundary AND effective compression. A single large file triggers it too because its extendedFile inode carries one block-size entry per data block (a 1 GB file at 128 KB blocksize needs ~32 KB of inode, spanning 4 metadata blocks by itself).

Fix: store a logical block index in updateInodeLocations, then have writeInodes track the actual on-disk byte offset of each metadata block as it writes them. After writeInodes returns, translateInodeLocations rewrites every inodeLocation.block and every directory entry's startBlock from logical index to real byte offset, before the directory table (which embeds those references) is written.

There's a matching TODO at finalize.go:274 noting "blockPosition calculations appear to be off" — this fixes that.

The reproducer test TestFinalizeInodesAcrossMetadataBlocks was added as a standalone failing test in a preceding PR; it passes after this fix.