### PR TITLE
fix: use %08x for MBR partition UUID to   preserve leading zeros

### DIFF
--- a/partition/mbr/table.go
+++ b/partition/mbr/table.go
@@ -110,7 +110,7 @@ func tableFromBytes(b []byte) (*Table, error) {
 
 func readPartitionTableUUID(b []byte) string {
 	ptUUID := b[partitionTableUUIDStart:partitionTableUUIDEnd]
-	return fmt.Sprintf("%x", binary.LittleEndian.Uint32(ptUUID))
+	return fmt.Sprintf("%08x", binary.LittleEndian.Uint32(ptUUID))
 }
 
 // UUID returns the partition table UUID used to identify disks


### PR DESCRIPTION
Fixes #380

`readPartitionTableUUID()` uses `%x` to format the 4-byte MBR disk signature, which drops leading zeros. This causes a mismatch with the Linux kernel's fixed 8-digit format (`%08x`).

For example, disk signature `0x000A57DF` produces `a57df-01` instead of the expected `000a57df-01`, breaking `/dev/disk/by-partuuid/`lookups.

 Change `%x` → `%08x` to match the kernel and libblkid behavior.