### PR TITLE
fix(iso9660): handle unspecified timestamps in volume descriptors

### DIFF
--- a/filesystem/iso9660/volume_descriptor.go
+++ b/filesystem/iso9660/volume_descriptor.go
@@ -223,19 +223,26 @@ func volumeDescriptorFromBytes(b []byte) (volumeDescriptor, error) {
 func parsePrimaryVolumeDescriptor(b []byte) (*primaryVolumeDescriptor, error) {
 	blocksize := binary.LittleEndian.Uint16(b[128:130])
 
-	creation, err := decBytesToTime(b[813 : 813+17])
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert creation date/time from bytes: %v", err)
-	}
-	modification, err := decBytesToTime(b[830 : 830+17])
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert modification date/time from bytes: %v", err)
-	}
 	// expiration can be never
 	nullBytes := []byte{48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 0}
-	var expiration, effective time.Time
+	var err error
+	var creation, modification, expiration, effective time.Time
+	creationBytes := b[813 : 813+17]
+	modificationBytes := b[830 : 830+17]
 	expirationBytes := b[847 : 847+17]
 	effectiveBytes := b[864 : 864+17]
+	if !bytes.Equal(creationBytes, nullBytes) {
+		creation, err = decBytesToTime(creationBytes)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert creation date/time from bytes: %v", err)
+		}
+	}
+	if !bytes.Equal(modificationBytes, nullBytes) {
+		modification, err = decBytesToTime(modificationBytes)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert modification date/time from bytes: %v", err)
+		}
+	}
 	if !bytes.Equal(expirationBytes, nullBytes) {
 		expiration, err = decBytesToTime(expirationBytes)
 		if err != nil {
@@ -324,19 +331,26 @@ func parseSupplementaryVolumeDescriptor(b []byte) (*supplementaryVolumeDescripto
 	volumesize := binary.LittleEndian.Uint32(b[80:84])
 	volumesizeBytes := uint64(blocksize) * uint64(volumesize)
 
-	creation, err := decBytesToTime(b[813 : 813+17])
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert creation date/time from bytes: %v", err)
-	}
-	modification, err := decBytesToTime(b[830 : 830+17])
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert modification date/time from bytes: %v", err)
-	}
 	// expiration can be never
 	nullBytes := []byte{48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 0}
-	var expiration, effective time.Time
+	var err error
+	var creation, modification, expiration, effective time.Time
+	creationBytes := b[813 : 813+17]
+	modificationBytes := b[830 : 830+17]
 	expirationBytes := b[847 : 847+17]
 	effectiveBytes := b[864 : 864+17]
+	if !bytes.Equal(creationBytes, nullBytes) {
+		creation, err = decBytesToTime(creationBytes)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert creation date/time from bytes: %v", err)
+		}
+	}
+	if !bytes.Equal(modificationBytes, nullBytes) {
+		modification, err = decBytesToTime(modificationBytes)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert modification date/time from bytes: %v", err)
+		}
+	}
 	if !bytes.Equal(expirationBytes, nullBytes) {
 		expiration, err = decBytesToTime(expirationBytes)
 		if err != nil {

--- a/filesystem/iso9660/volume_descriptor_internal_test.go
+++ b/filesystem/iso9660/volume_descriptor_internal_test.go
@@ -280,6 +280,27 @@ func TestParsePrimaryVolumeDescriptor(t *testing.T) {
 		t.Log(diff)
 	}
 }
+func TestParsePrimaryVolumeDescriptorNullTimestamps(t *testing.T) {
+	validPvd, validBytes, err := get9660PrimaryVolumeDescriptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nullBytes := []byte{48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 0}
+	dateLocations := []int{813, 830, 847, 864}
+	for _, loc := range dateLocations {
+		copy(validBytes[loc:loc+17], nullBytes)
+	}
+
+	pvd, err := parsePrimaryVolumeDescriptor(validBytes)
+	if err != nil {
+		t.Fatalf("error parsing primary volume descriptor with null timestamps: %v", err)
+	}
+	if diff := comparePrimaryVolumeDescriptorsIgnoreDates(pvd, validPvd); diff != nil {
+		t.Errorf("Mismatched primary volume descriptor, actual vs expected")
+		t.Log(diff)
+	}
+}
 func TestPrimaryVolumeDescriptorType(t *testing.T) {
 	pvd := &primaryVolumeDescriptor{}
 	if pvd.Type() != volumeDescriptorPrimary {


### PR DESCRIPTION
ECMA-119 Section 9.4.27.2 defines all-zero timestamp fields as "not specified", which is a valid state for all four volume descriptor timestamp fields (creation, modification, expiration, effective).

The expiration and effective fields were already handled, but creation and modification were not, causing a parse error when handling ISOs with unspecified timestamps.

Adds a regression test for PVD parsing with null timestamps.