### PR TITLE
fix(iso9660): include final 4-byte system use entry in parsing

### DIFF
--- a/filesystem/iso9660/directoryentrysystemuseextension.go
+++ b/filesystem/iso9660/directoryentrysystemuseextension.go
@@ -511,7 +511,7 @@ func parseDirectoryEntryExtensions(b []byte, handlers []suspExtension) ([]direct
 	entries := make([]directoryEntrySystemUseExtension, 0)
 	lastEntryBySignature := map[string]directoryEntrySystemUseExtension{}
 	// minimum size of 4 bytes for any SUSP entry
-	for i := 0; i+4 < len(b); {
+	for i := 0; i+3 < len(b); {
 		// get the indicator
 		signature := string(b[i : i+2])
 		size := b[i+2]

--- a/filesystem/iso9660/directoryentrysystemuseextension_internal_test.go
+++ b/filesystem/iso9660/directoryentrysystemuseextension_internal_test.go
@@ -1,0 +1,14 @@
+package iso9660
+
+import "testing"
+
+func TestParseDirectoryEntryExtensionsFourByteEntry(t *testing.T) {
+	fourByteEntry := []byte{'S', 'T', 4, 1}
+	entries, err := parseDirectoryEntryExtensions(fourByteEntry, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
The loop condition `i+4 < len(b)` incorrectly excludes a valid 4-byte System Use Field when it falls at the end of a System Use Area, since the 4-byte field occupies bytes i through i+3.

Updated to `i+3 < len(b)`

Fixes #127