### PR TITLE
fix(iso9660): handle zero-filled system use area padding in directory entries

### DIFF
--- a/filesystem/iso9660/directoryentrysystemuseextension.go
+++ b/filesystem/iso9660/directoryentrysystemuseextension.go
@@ -515,6 +515,9 @@ func parseDirectoryEntryExtensions(b []byte, handlers []suspExtension) ([]direct
 		// get the indicator
 		signature := string(b[i : i+2])
 		size := b[i+2]
+		if size < 4 {
+			break
+		}
 		suspBytes := b[i : i+int(size)]
 		var (
 			entry directoryEntrySystemUseExtension

--- a/filesystem/iso9660/directoryentrysystemuseextension_internal_test.go
+++ b/filesystem/iso9660/directoryentrysystemuseextension_internal_test.go
@@ -12,3 +12,14 @@ func TestParseDirectoryEntryExtensionsFourByteEntry(t *testing.T) {
 		t.Errorf("expected 1 entry, got %d", len(entries))
 	}
 }
+
+func TestParseDirectoryEntryExtensionsZeroPadding(t *testing.T) {
+	zeroPadding := []byte{0, 0, 0, 0}
+	entries, err := parseDirectoryEntryExtensions(zeroPadding, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no entries, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
Added a check in parseDirectoryEntryExtensions to treat any entry with a length less than 4 as the end of data, aligning with the SUSP spec's minimum 4-byte header requirement.

Fixes #388