### PR TITLE
ext4: expose inode metadata via FileInfo.Sys()

### DIFF
--- a/filesystem/ext4/ext4_test.go
+++ b/filesystem/ext4/ext4_test.go
@@ -808,3 +808,104 @@ func TestChown(t *testing.T) {
 		}
 	})
 }
+
+func TestStatSysInodeMetadata(t *testing.T) {
+	f, err := os.Open(imgFile)
+	if err != nil {
+		t.Fatalf("Error opening test image: %v", err)
+	}
+	defer f.Close()
+
+	b := file.New(f, true)
+	fs, err := Read(b, 100*MB, 0, 512)
+	if err != nil {
+		t.Fatalf("Error reading filesystem: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"regular file", "/random.dat"},
+		{"directory", "/foo"},
+		{"root", "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fi, err := fs.Stat(tt.path)
+			if err != nil {
+				t.Fatalf("Stat failed: %v", err)
+			}
+			sys := fi.Sys()
+			if sys == nil {
+				t.Fatalf("Sys() returned nil")
+			}
+			stat, ok := sys.(*StatT)
+			if !ok {
+				t.Fatalf("Sys() did not return *StatT, got %T", sys)
+			}
+			if stat.Ino == 0 {
+				t.Errorf("expected non-zero inode number, got 0")
+			}
+			if stat.Nlink == 0 {
+				t.Errorf("expected non-zero hardlink count, got 0")
+			}
+			// modify time on FileInfo should match the inode-derived value through Stat
+			if fi.ModTime().IsZero() {
+				t.Errorf("ModTime is zero")
+			}
+			// timestamps must be plausible: not zero, and not absurdly in the future
+			if stat.AccessTime.IsZero() {
+				t.Errorf("AccessTime is zero")
+			}
+			if stat.ChangeTime.IsZero() {
+				t.Errorf("ChangeTime is zero")
+			}
+			upper := time.Now().AddDate(100, 0, 0)
+			lower := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+			if stat.AccessTime.After(upper) || stat.AccessTime.Before(lower) {
+				t.Errorf("AccessTime %v outside plausible range", stat.AccessTime)
+			}
+			if stat.ChangeTime.After(upper) || stat.ChangeTime.Before(lower) {
+				t.Errorf("ChangeTime %v outside plausible range", stat.ChangeTime)
+			}
+			// Confirm Stat returns stable values across repeated calls.
+			fi2, err := fs.Stat(tt.path)
+			if err != nil {
+				t.Fatalf("second Stat failed: %v", err)
+			}
+			stat2, ok := fi2.Sys().(*StatT)
+			if !ok {
+				t.Fatalf("second Sys() did not return *StatT")
+			}
+			if stat.UID != stat2.UID || stat.GID != stat2.GID {
+				t.Errorf("UID/GID not stable: %d:%d vs %d:%d", stat.UID, stat.GID, stat2.UID, stat2.GID)
+			}
+			if stat.Ino != stat2.Ino {
+				t.Errorf("inode number not stable: %d vs %d", stat.Ino, stat2.Ino)
+			}
+		})
+	}
+
+	t.Run("symlink target", func(t *testing.T) {
+		// On the test image, /symlink.dat is a symlink to random.dat. fs.Stat returns the
+		// link inode's metadata, which carries LinkTarget for symlinks.
+		// We look up the symlink via the directory entry path since fs.Stat may follow it.
+		_, entry, err := fs.getEntryAndParent("/symlink.dat")
+		if err != nil {
+			t.Fatalf("getEntryAndParent failed: %v", err)
+		}
+		if entry == nil {
+			t.Fatalf("symlink entry not found")
+		}
+		in, err := fs.readInode(entry.inode)
+		if err != nil {
+			t.Fatalf("readInode failed: %v", err)
+		}
+		s := in.stat()
+		if in.fileType == fileTypeSymbolicLink && s.LinkTarget == "" {
+			t.Errorf("expected non-empty LinkTarget for symlink inode")
+		}
+	})
+}

--- a/filesystem/ext4/fileinfo.go
+++ b/filesystem/ext4/fileinfo.go
@@ -16,13 +16,38 @@ type FileInfo struct {
 	sys     *StatT
 }
 
+// StatT carries ext4-specific metadata returned by FileInfo.Sys().
 type StatT struct {
-	UID   uint32
-	GID   uint32
-	Major uint32
-	Minor uint32
-	Ino   uint32
-	Nlink uint16
+	UID        uint32
+	GID        uint32
+	Major      uint32
+	Minor      uint32
+	Ino        uint32
+	Nlink      uint16
+	Blocks     uint64
+	AccessTime time.Time
+	ChangeTime time.Time
+	CreateTime time.Time
+	Flags      InodeFlags
+	LinkTarget string
+}
+
+// InodeFlags exposes the practically useful subset of ext4 inode flags.
+type InodeFlags struct {
+	Immutable          bool
+	AppendOnly         bool
+	NoDump             bool
+	NoAtime            bool
+	Synchronous        bool
+	Compressed         bool
+	Encrypted          bool
+	HashedIndexes      bool
+	JournalData        bool
+	HugeFile           bool
+	Extents            bool
+	ExtendedAttributes bool
+	InlineData         bool
+	TopDirectory       bool
 }
 
 // IsDir abbreviation for Mode().IsDir()
@@ -52,7 +77,7 @@ func (fi *FileInfo) Size() int64 {
 	return fi.size
 }
 
-// Sys underlying data source - not supported yet and so will return nil
+// Sys returns the underlying *StatT with ext4-specific metadata.
 func (fi *FileInfo) Sys() interface{} {
 	return fi.sys
 }

--- a/filesystem/ext4/inode.go
+++ b/filesystem/ext4/inode.go
@@ -174,13 +174,41 @@ func (i *inode) deviceNumber() (major, minor uint32) {
 
 func (i *inode) stat() *StatT {
 	major, minor := i.deviceNumber()
-	return &StatT{
-		UID:   i.owner,
-		GID:   i.group,
-		Major: major,
-		Minor: minor,
-		Ino:   i.number,
-		Nlink: i.hardLinks,
+	s := &StatT{
+		UID:        i.owner,
+		GID:        i.group,
+		Major:      major,
+		Minor:      minor,
+		Ino:        i.number,
+		Nlink:      i.hardLinks,
+		Blocks:     i.blocks,
+		AccessTime: i.accessTime,
+		ChangeTime: i.changeTime,
+		CreateTime: i.createTime,
+		LinkTarget: i.linkTarget,
+	}
+	if i.flags != nil {
+		s.Flags = inodeFlagsToInodeFlags(i.flags)
+	}
+	return s
+}
+
+func inodeFlagsToInodeFlags(f *inodeFlags) InodeFlags {
+	return InodeFlags{
+		Immutable:          f.immutable,
+		AppendOnly:         f.appendOnly,
+		NoDump:             f.noDump,
+		NoAtime:            f.noAccessTimeUpdate,
+		Synchronous:        f.synchronous,
+		Compressed:         f.compressed,
+		Encrypted:          f.encryptedInode,
+		HashedIndexes:      f.hashedDirectoryIndexes,
+		JournalData:        f.alwaysJournal,
+		HugeFile:           f.hugeFile,
+		Extents:            f.usesExtents,
+		ExtendedAttributes: f.extendedAttributes,
+		InlineData:         f.inlineData,
+		TopDirectory:       f.topDirectory,
 	}
 }
 


### PR DESCRIPTION
Closes #301.

## What this does

`filesystem/ext4.FileSystem.Stat()` returns an `fs.FileInfo` whose `Sys()` previously exposed only `UID`/`GID` (and, as of recent upstream changes, `Major`/`Minor`/`Ino`/`Nlink`). The on-disk ext4 inode carries much more — block count, access/change/create timestamps, symlink target, and a flag bitmap — and this PR surfaces all of it through the existing `Sys()` escape hatch, matching the idiomatic Go pattern used by `os.Stat` returning `*syscall.Stat_t`.

Changes are **additive** — the existing fields on `ext4.StatT` are unchanged, and `FileSystem.Stat`'s signature is unchanged. No change to the `filesystem.FileSystem` interface.

### `StatT` now carries

| Field | Source | Added in |
|---|---|---|
| `UID`, `GID` | `inode.owner` / `inode.group` | (already there) |
| `Major`, `Minor` | `inode.deviceNumber()` | (already there) |
| `Ino` | `inode.number` | (already there) |
| `Nlink` | `inode.hardLinks` | (already there) |
| `Blocks uint64` | `inode.blocks` | this PR |
| `AccessTime time.Time` | `inode.accessTime` | this PR |
| `ChangeTime time.Time` | `inode.changeTime` | this PR |
| `CreateTime time.Time` | `inode.createTime` | this PR |
| `LinkTarget string` | `inode.linkTarget` (symlinks) | this PR |
| `Flags InodeFlags` | curated subset of `inodeFlags` | this PR |

A new exported `InodeFlags` struct exposes the practically useful flag bits — Immutable, AppendOnly, NoDump, NoAtime, Synchronous, Compressed, Encrypted, HashedIndexes, JournalData, HugeFile, Extents, ExtendedAttributes, InlineData, TopDirectory. The internal `inodeFlags` struct stays unexported.

The existing `(i *inode).stat()` helper is extended to populate the new fields, so all three `FileInfo` construction sites (`FileSystem.Stat`, `File.Stat`, `directoryEntryInfo.Info`) continue to use a single source of truth.

### Usage

```go
fi, _ := fs.Stat("/some/path")
if st, ok := fi.Sys().(*ext4.StatT); ok {
    fmt.Println(st.Ino, st.Nlink, st.CreateTime, st.Flags.Immutable)
    if st.LinkTarget != "" {
        fmt.Println("symlink ->", st.LinkTarget)
    }
}
```

### Tests

New `TestStatSysInodeMetadata` exercises `/random.dat`, `/foo`, `/`, and `/symlink.dat` from the existing test image — asserts non-zero inode, plausible timestamps, stable values across repeated `Stat` calls, and non-empty `LinkTarget` for symlinks.

---

## Follow-up PRs

If this lands, three sibling PRs apply the same `Sys()`-based pattern to the other read-supporting filesystems. Each is independent and reviewable on its own.

### iso9660 — [#394](https://github.com/diskfs/go-diskfs/pull/394) (draft)

`directoryEntry.Sys()` currently returns `*RockRidgeInfo` when Rock Ridge is present, otherwise `nil`. The follow-up replaces `RockRidgeInfo` with a richer `iso9660.StatT` always returned by `Sys()`, carrying ISO9660 fields (`Location`, `VolumeSequence`, `IsHidden`, `IsAssociated`, `ExtAttrSize`, `HasExtendedAttrs`, `HasOwnerGroupPermissions`) plus Rock Ridge fields parsed from PX and SL records (`UID`, `GID`, `NLink`, `Inode`, `LinkTarget`, `RockRidge bool`). RR fields stay zero-valued when no extensions are present. This is a breaking change for any caller currently asserting `*RockRidgeInfo`; the in-repo test assertions are updated as part of the PR.

### squashfs — [#395](https://github.com/diskfs/go-diskfs/pull/395) (draft)

squashfs is the outlier: `Sys()` already returns `*directoryEntry` (aliased as the public `squashfs.FileStat`), which already exposes `UID()`, `GID()`, `Xattrs()`, `Readlink()` as accessor methods. To stay consistent with that existing public surface, the follow-up adds two more accessors — `Inode() uint32` and `InodeType() string` — rather than introducing a parallel `StatT` struct. No breaking change to the existing `FileStat` type.

### fat (fat12 / fat16 / fat32) — [#396](https://github.com/diskfs/go-diskfs/pull/396) (draft)

#### The architectural picture

The recent FAT12/16 support PR (#358) restructured the FAT codebase: the actual implementation now lives in `filesystem/fat12`, and `filesystem/fat32` + `filesystem/fat16` are thin wrappers that embed `*fat12.FileSystem` and override `Type()`. Public API parity with the old fat32 surface is preserved through Go type aliases — for example, `type SectorSize = fat12.SectorSize` already exists in `fat32.go`. A type alias (`A = B`) is *identity*, not a new named type, so `fat32.SectorSize` and `fat12.SectorSize` are literally the same type.

The follow-up applies that same pattern for the new `StatT`. The implementation defines `fat12.StatT` once and a `(*directoryEntry).stat()` helper that populates it from `parseDirEntries` data already on the entry. Then:

```go
// filesystem/fat12/fileinfo.go — single source of truth
type StatT struct {
    ReadOnly, Hidden, System, Archive, VolumeLabel bool
    CreateTime, AccessTime                          time.Time
    Cluster                                         uint32
}

// filesystem/fat32/fat32.go
type StatT = fat12.StatT

// filesystem/fat16/fat16.go
type StatT = fat12.StatT
```

#### Why this is the right shape (not three separate copies)

1. **One implementation, three packages covered.** `directoryEntry.stat()` is defined once. `fat16` and `fat32` inherit working `Sys()` automatically because they reuse `fat12`'s `directoryEntry.Info()` and `File.Stat()` code paths.

2. **Same type across packages, by design.** Because `type StatT = fat12.StatT` is an alias (not a new named type with the same field shape), a value of `*fat32.StatT` *is* a `*fat12.StatT`. A downstream library that wants to handle any FAT variant can type-assert against `*fat12.StatT` once and have it match all three — same way `*syscall.Stat_t` matches any UNIX filesystem reachable through `os.Stat`. Callers using a specific FAT package still write the natural import (`fi.Sys().(*fat32.StatT)` works for fat32 users) without forcing them to learn about the fat12 base package.

3. **No drift risk.** If FAT16 later needs a new attribute exposed, it goes in `fat12.StatT` and the other two get it for free. The alternative (three separate `StatT` structs with the same field shape) would inevitably diverge.

4. **Mirrors the upstream architectural choice already made.** This isn't introducing a new pattern; `fat16`/`fat32` are already wrappers around `fat12.FileSystem` and their public types are already aliases. Adding `StatT` as an alias is consistent with how `SectorSize` works today — anything else would create two competing conventions in the same package.

#### Fields

All populated from data `parseDirEntries` already extracts; no new parsing. Attribute bits (`ReadOnly`, `Hidden`, `System`, `Archive`, `VolumeLabel`), the two FAT timestamps that don't map to `ModTime()` (`CreateTime`, `AccessTime`), and the file's starting `Cluster`.
