### PR TITLE
iso9660: expose rich metadata via FileInfo.Sys()

### DIFF
--- a/filesystem/iso9660/combined_xorriso_test.go
+++ b/filesystem/iso9660/combined_xorriso_test.go
@@ -141,10 +141,10 @@ func TestCombinedRockRidgeJolietElTorito(t *testing.T) {
 			if info.Mode()&os.ModeSymlink == 0 {
 				t.Errorf("link.txt: expected symlink mode, got %v", info.Mode())
 			}
-			if rri, ok := info.Sys().(*iso9660.RockRidgeInfo); !ok {
-				t.Error("link.txt: Sys() did not return *RockRidgeInfo")
-			} else if rri.Symlink != "target.txt" {
-				t.Errorf("link.txt: symlink target %q, want %q", rri.Symlink, "target.txt")
+			if stat, ok := info.Sys().(*iso9660.StatT); !ok {
+				t.Error("link.txt: Sys() did not return *StatT")
+			} else if stat.LinkTarget != "target.txt" {
+				t.Errorf("link.txt: symlink target %q, want %q", stat.LinkTarget, "target.txt")
 			}
 		}
 	}

--- a/filesystem/iso9660/directoryentry.go
+++ b/filesystem/iso9660/directoryentry.go
@@ -560,6 +560,36 @@ func (de *directoryEntry) Sys() interface{} {
 	return de.statT()
 }
 
+func (de *directoryEntry) statT() *StatT {
+	s := &StatT{
+		ExtAttrSize:              de.extAttrSize,
+		Location:                 de.location,
+		VolumeSequence:           de.volumeSequence,
+		IsHidden:                 de.isHidden,
+		IsAssociated:             de.isAssociated,
+		HasExtendedAttrs:         de.hasExtendedAttrs,
+		HasOwnerGroupPermissions: de.hasOwnerGroupPermissions,
+	}
+	for _, ext := range de.extensions {
+		switch e := ext.(type) {
+		case rockRidgePosixAttributes:
+			s.RockRidge = true
+			s.UID = e.uid
+			s.GID = e.gid
+			s.NLink = e.linkCount
+			s.Inode = uint32(e.serial)
+		case rockRidgeSymlink:
+			s.RockRidge = true
+			if !e.continued {
+				s.LinkTarget = e.name
+			}
+		case rockRidgeName, rockRidgeTimestamps, rockRidgeChildDirectory, rockRidgeParentDirectory, rockRidgeRelocatedDirectory, rockRidgeSparseFile, rockRidgePosixDeviceNumber:
+			s.RockRidge = true
+		}
+	}
+	return s
+}
+
 // Info returns the FileInfo structure, which directoryEntry already implements
 func (de *directoryEntry) Info() (os.FileInfo, error) {
 	return de, nil

--- a/filesystem/iso9660/directoryentry.go
+++ b/filesystem/iso9660/directoryentry.go
@@ -555,34 +555,9 @@ func (de *directoryEntry) IsDir() bool {
 	return de.isSubdirectory
 }
 
-// RockRidgeInfo holds POSIX metadata from Rock Ridge extensions.
-type RockRidgeInfo struct {
-	UID     uint32
-	GID     uint32
-	Nlink   uint32
-	Mode    os.FileMode
-	Symlink string
-}
-
-// Sys() interface{}   // underlying data source (can return nil)
+// Sys returns *StatT with ISO9660 and Rock Ridge metadata.
 func (de *directoryEntry) Sys() interface{} {
-	for _, ext := range de.extensions {
-		if px, ok := ext.(rockRidgePosixAttributes); ok {
-			rri := &RockRidgeInfo{
-				UID:   px.uid,
-				GID:   px.gid,
-				Nlink: px.linkCount,
-				Mode:  px.mode,
-			}
-			for _, ext2 := range de.extensions {
-				if sl, ok := ext2.(rockRidgeSymlink); ok {
-					rri.Symlink = sl.name
-				}
-			}
-			return rri
-		}
-	}
-	return nil
+	return de.statT()
 }
 
 // Info returns the FileInfo structure, which directoryEntry already implements

--- a/filesystem/iso9660/fileinfo.go
+++ b/filesystem/iso9660/fileinfo.go
@@ -31,33 +31,3 @@ type StatT struct {
 	// RockRidge is true if any Rock Ridge extension was found on the entry.
 	RockRidge bool
 }
-
-func (de *directoryEntry) statT() *StatT {
-	s := &StatT{
-		ExtAttrSize:              de.extAttrSize,
-		Location:                 de.location,
-		VolumeSequence:           de.volumeSequence,
-		IsHidden:                 de.isHidden,
-		IsAssociated:             de.isAssociated,
-		HasExtendedAttrs:         de.hasExtendedAttrs,
-		HasOwnerGroupPermissions: de.hasOwnerGroupPermissions,
-	}
-	for _, ext := range de.extensions {
-		switch e := ext.(type) {
-		case rockRidgePosixAttributes:
-			s.RockRidge = true
-			s.UID = e.uid
-			s.GID = e.gid
-			s.NLink = e.linkCount
-			s.Inode = uint32(e.serial)
-		case rockRidgeSymlink:
-			s.RockRidge = true
-			if !e.continued {
-				s.LinkTarget = e.name
-			}
-		case rockRidgeName, rockRidgeTimestamps, rockRidgeChildDirectory, rockRidgeParentDirectory, rockRidgeRelocatedDirectory, rockRidgeSparseFile, rockRidgePosixDeviceNumber:
-			s.RockRidge = true
-		}
-	}
-	return s
-}

--- a/filesystem/iso9660/fileinfo.go
+++ b/filesystem/iso9660/fileinfo.go
@@ -1,0 +1,63 @@
+package iso9660
+
+// StatT is the ISO9660-specific metadata returned by directoryEntry.Sys().
+// Rock Ridge fields are zero-valued when no Rock Ridge extensions are present.
+type StatT struct {
+	// ExtAttrSize is the size of the extended attribute record in bytes.
+	ExtAttrSize uint8
+	// Location is the extent LBA where the file's data begins.
+	Location uint32
+	// VolumeSequence is the volume sequence number.
+	VolumeSequence uint16
+	// IsHidden reports whether the hidden flag is set.
+	IsHidden bool
+	// IsAssociated reports whether the associated file flag is set.
+	IsAssociated bool
+	// HasExtendedAttrs reports whether the extended-attributes flag is set.
+	HasExtendedAttrs bool
+	// HasOwnerGroupPermissions reports whether owner/group permissions are present.
+	HasOwnerGroupPermissions bool
+
+	// UID is the owner user ID from a Rock Ridge PX record.
+	UID uint32
+	// GID is the owner group ID from a Rock Ridge PX record.
+	GID uint32
+	// NLink is the hard-link count from a Rock Ridge PX record.
+	NLink uint32
+	// Inode is the inode/serial number from a Rock Ridge PX record.
+	Inode uint32
+	// LinkTarget is the symbolic-link target from Rock Ridge SL records, only set when not continued.
+	LinkTarget string
+	// RockRidge is true if any Rock Ridge extension was found on the entry.
+	RockRidge bool
+}
+
+func (de *directoryEntry) statT() *StatT {
+	s := &StatT{
+		ExtAttrSize:              de.extAttrSize,
+		Location:                 de.location,
+		VolumeSequence:           de.volumeSequence,
+		IsHidden:                 de.isHidden,
+		IsAssociated:             de.isAssociated,
+		HasExtendedAttrs:         de.hasExtendedAttrs,
+		HasOwnerGroupPermissions: de.hasOwnerGroupPermissions,
+	}
+	for _, ext := range de.extensions {
+		switch e := ext.(type) {
+		case rockRidgePosixAttributes:
+			s.RockRidge = true
+			s.UID = e.uid
+			s.GID = e.gid
+			s.NLink = e.linkCount
+			s.Inode = uint32(e.serial)
+		case rockRidgeSymlink:
+			s.RockRidge = true
+			if !e.continued {
+				s.LinkTarget = e.name
+			}
+		case rockRidgeName, rockRidgeTimestamps, rockRidgeChildDirectory, rockRidgeParentDirectory, rockRidgeRelocatedDirectory, rockRidgeSparseFile, rockRidgePosixDeviceNumber:
+			s.RockRidge = true
+		}
+	}
+	return s
+}

--- a/filesystem/iso9660/finalize_test.go
+++ b/filesystem/iso9660/finalize_test.go
@@ -714,13 +714,13 @@ func testRockRidgeSymlinks(t *testing.T) {
 		if info.Mode()&os.ModeSymlink == 0 {
 			t.Errorf("symlink %s: mode %v does not have ModeSymlink", st.name, info.Mode())
 		}
-		rri, ok := info.Sys().(*iso9660.RockRidgeInfo)
-		if !ok || rri == nil {
-			t.Errorf("symlink %s: Sys() did not return *RockRidgeInfo", st.name)
+		stat, ok := info.Sys().(*iso9660.StatT)
+		if !ok || stat == nil {
+			t.Errorf("symlink %s: Sys() did not return *StatT", st.name)
 			continue
 		}
-		if rri.Symlink != st.target {
-			t.Errorf("symlink %s: got target %q, want %q", st.name, rri.Symlink, st.target)
+		if stat.LinkTarget != st.target {
+			t.Errorf("symlink %s: got target %q, want %q", st.name, stat.LinkTarget, st.target)
 		}
 	}
 }

--- a/filesystem/iso9660/iso9660_test.go
+++ b/filesystem/iso9660/iso9660_test.go
@@ -663,3 +663,81 @@ func TestIso9660Finalize(t *testing.T) {
 		})
 	}
 }
+
+func findDirEntry(entries []iofs.DirEntry, name string) iofs.DirEntry {
+	for _, e := range entries {
+		if e.Name() == name {
+			return e
+		}
+	}
+	return nil
+}
+
+func TestSysStatT(t *testing.T) {
+	fs, err := getValidIso9660FSReadOnly()
+	if err != nil {
+		t.Fatalf("Failed to get read-only ISO9660 filesystem: %v", err)
+	}
+	entries, err := fs.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir returned error: %v", err)
+	}
+	de := findDirEntry(entries, "README.MD")
+	if de == nil {
+		t.Fatalf("README.MD not found in root")
+	}
+	fi, err := de.Info()
+	if err != nil {
+		t.Fatalf("Info returned error: %v", err)
+	}
+	sys := fi.Sys()
+	st, ok := sys.(*iso9660.StatT)
+	if !ok {
+		t.Fatalf("Sys() returned %T, want *iso9660.StatT", sys)
+	}
+	if st.RockRidge {
+		t.Errorf("RockRidge = true, want false on plain ISO")
+	}
+	if st.Location == 0 {
+		t.Errorf("Location = 0, want non-zero extent LBA")
+	}
+	if st.IsHidden {
+		t.Errorf("IsHidden = true, want false for README.MD")
+	}
+	if st.LinkTarget != "" {
+		t.Errorf("LinkTarget = %q, want empty on plain ISO", st.LinkTarget)
+	}
+}
+
+func TestSysStatTRockRidge(t *testing.T) {
+	fs, err := getValidRockRidgeFSReadOnly()
+	if err != nil {
+		t.Fatalf("Failed to get read-only Rock Ridge filesystem: %v", err)
+	}
+	entries, err := fs.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir returned error: %v", err)
+	}
+	de := findDirEntry(entries, "README.md")
+	if de == nil {
+		t.Fatalf("README.md not found in root")
+	}
+	fi, err := de.Info()
+	if err != nil {
+		t.Fatalf("Info returned error: %v", err)
+	}
+	sys := fi.Sys()
+	st, ok := sys.(*iso9660.StatT)
+	if !ok {
+		t.Fatalf("Sys() returned %T, want *iso9660.StatT", sys)
+	}
+	if !st.RockRidge {
+		t.Errorf("RockRidge = false, want true on Rock Ridge ISO")
+	}
+	if st.NLink < 1 {
+		t.Errorf("NLink = %d, want >= 1", st.NLink)
+	}
+	if st.Location == 0 {
+		t.Errorf("Location = 0, want non-zero extent LBA")
+	}
+}

--- a/filesystem/iso9660/rockridge_xorriso_test.go
+++ b/filesystem/iso9660/rockridge_xorriso_test.go
@@ -189,12 +189,12 @@ func TestRockRidgeWriteReadRoundTrip(t *testing.T) {
 			if info.Mode()&os.ModeSymlink == 0 {
 				t.Errorf("link.txt: expected symlink mode, got %v", info.Mode())
 			}
-			rri, ok := info.Sys().(*iso9660.RockRidgeInfo)
+			stat, ok := info.Sys().(*iso9660.StatT)
 			if !ok {
-				t.Fatal("link.txt: Sys() did not return *RockRidgeInfo")
+				t.Fatal("link.txt: Sys() did not return *StatT")
 			}
-			if rri.Symlink != "target.txt" {
-				t.Errorf("link.txt: got symlink target %q, want %q", rri.Symlink, "target.txt")
+			if stat.LinkTarget != "target.txt" {
+				t.Errorf("link.txt: got symlink target %q, want %q", stat.LinkTarget, "target.txt")
 			}
 		}
 	}
@@ -400,12 +400,12 @@ func TestRockRidgeGoReadXorrisoOutput(t *testing.T) {
 			t.Errorf("link: expected symlink mode, got %v", info.Mode())
 		}
 		// Check symlink target via Sys()
-		rri, ok := info.Sys().(*iso9660.RockRidgeInfo)
+		stat, ok := info.Sys().(*iso9660.StatT)
 		if !ok {
-			t.Fatal("link: Sys() did not return *RockRidgeInfo")
+			t.Fatal("link: Sys() did not return *StatT")
 		}
-		if rri.Symlink != "hello.txt" {
-			t.Errorf("link: got symlink target %q, want %q", rri.Symlink, "hello.txt")
+		if stat.LinkTarget != "hello.txt" {
+			t.Errorf("link: got symlink target %q, want %q", stat.LinkTarget, "hello.txt")
 		}
 	})
 
@@ -415,16 +415,16 @@ func TestRockRidgeGoReadXorrisoOutput(t *testing.T) {
 		if !ok {
 			t.Skip("hello.txt not found")
 		}
-		rri, ok := info.Sys().(*iso9660.RockRidgeInfo)
+		stat, ok := info.Sys().(*iso9660.StatT)
 		if !ok {
-			t.Fatal("hello.txt: Sys() did not return *RockRidgeInfo")
+			t.Fatal("hello.txt: Sys() did not return *StatT")
 		}
 		// xorriso sets UID/GID to 0 by default in Docker (running as root)
-		if rri.UID != 0 {
-			t.Logf("hello.txt: UID = %d (expected 0 from Docker/xorriso)", rri.UID)
+		if stat.UID != 0 {
+			t.Logf("hello.txt: UID = %d (expected 0 from Docker/xorriso)", stat.UID)
 		}
-		if rri.GID != 0 {
-			t.Logf("hello.txt: GID = %d (expected 0 from Docker/xorriso)", rri.GID)
+		if stat.GID != 0 {
+			t.Logf("hello.txt: GID = %d (expected 0 from Docker/xorriso)", stat.GID)
 		}
 	})
 }


### PR DESCRIPTION
Refs #301. Sibling of #393 (ext4) — same pattern, applied to iso9660.

## What this does

`filesystem/iso9660/directoryEntry.Sys()` previously returned `*RockRidgeInfo` when Rock Ridge extensions were present on the entry, otherwise `nil`. That was a partial answer to #301: callers could only see uid/gid/mode/symlink, only on Rock Ridge ISOs, and the plain ISO9660 metadata (extent location, volume sequence, hidden flag, etc.) was invisible.

This PR replaces `RockRidgeInfo` with a richer `iso9660.StatT` that `Sys()` always returns, carrying both the plain ISO9660 directory-entry fields and the Rock Ridge fields when present.

### Fields

| Source | Field |
|---|---|
| ISO9660 directory entry | `ExtAttrSize uint8` |
| | `Location uint32` (extent LBA) |
| | `VolumeSequence uint16` |
| | `IsHidden bool` |
| | `IsAssociated bool` |
| | `HasExtendedAttrs bool` |
| | `HasOwnerGroupPermissions bool` |
| Rock Ridge PX record | `UID uint32` |
| | `GID uint32` |
| | `NLink uint32` |
| | `Inode uint32` |
| Rock Ridge SL record | `LinkTarget string` |
| (any RR record found) | `RockRidge bool` |

RR fields are zero-valued / `RockRidge=false` on non-RR ISOs.

### Breaking change — `RockRidgeInfo` removed

`RockRidgeInfo` was added recently (in #353) and exported, so removing it is a breaking change. In-repo callers in 4 test files are updated as part of this PR. External callers will need to switch:

```go
// before
if rri, ok := info.Sys().(*iso9660.RockRidgeInfo); ok {
    fmt.Println(rri.Symlink, rri.UID)
}

// after
if st, ok := info.Sys().(*iso9660.StatT); ok && st.RockRidge {
    fmt.Println(st.LinkTarget, st.UID)
}
```

The alternative — keeping `RockRidgeInfo` alongside the new `StatT` — would have left two competing return types for `Sys()` and split the metadata model in two. Given that `RockRidgeInfo` is fresh (one release) and only covers a subset of what callers actually want, supersession seems cleaner than coexistence. Open to keeping it as a deprecated alias if reviewers prefer.

### Tests

New `TestSysStatT` (plain ISO via `testdata/9660.iso`) and `TestSysStatTRockRidge` (RR ISO via `testdata/rockridge.iso`). Existing Rock Ridge tests (`combined_xorriso_test.go`, `finalize_test.go`, `rockridge_xorriso_test.go`) updated to assert on `*StatT` instead of `*RockRidgeInfo`.