### PR TITLE
squashfs: expose inode number and type via Sys()

### DIFF
--- a/filesystem/squashfs/directoryentry.go
+++ b/filesystem/squashfs/directoryentry.go
@@ -145,6 +145,53 @@ func (d *directoryEntry) Xattrs() map[string]string {
 	return d.xattrs
 }
 
+// Inode returns the squashfs inode number for this entry.
+func (d *directoryEntry) Inode() uint32 {
+	if d.inode == nil {
+		return 0
+	}
+	return d.inode.index()
+}
+
+// InodeType returns a human-readable name for the squashfs inode type.
+func (d *directoryEntry) InodeType() string {
+	if d.inode == nil {
+		return "unknown"
+	}
+	switch d.inode.inodeType() {
+	case inodeBasicDirectory:
+		return "basic-directory"
+	case inodeBasicFile:
+		return "basic-file"
+	case inodeBasicSymlink:
+		return "basic-symlink"
+	case inodeBasicBlock:
+		return "basic-block-device"
+	case inodeBasicChar:
+		return "basic-char-device"
+	case inodeBasicFifo:
+		return "basic-fifo"
+	case inodeBasicSocket:
+		return "basic-socket"
+	case inodeExtendedDirectory:
+		return "extended-directory"
+	case inodeExtendedFile:
+		return "extended-file"
+	case inodeExtendedSymlink:
+		return "extended-symlink"
+	case inodeExtendedBlock:
+		return "extended-block-device"
+	case inodeExtendedChar:
+		return "extended-char-device"
+	case inodeExtendedFifo:
+		return "extended-fifo"
+	case inodeExtendedSocket:
+		return "extended-socket"
+	default:
+		return "unknown"
+	}
+}
+
 // Readlink returns the destination of the symbolic link if this entry
 // is a symbolic link.
 //

--- a/filesystem/squashfs/squashfs_test.go
+++ b/filesystem/squashfs/squashfs_test.go
@@ -742,6 +742,72 @@ func TestSquashfsCreate(t *testing.T) {
 	}
 }
 
+func TestSquashfsInodeMetadata(t *testing.T) {
+	fs, err := getValidSquashfsFSReadOnly()
+	if err != nil {
+		t.Fatalf("Failed to get read-only squashfs filesystem: %v", err)
+	}
+
+	des, err := fs.ReadDir(".")
+	if err != nil {
+		t.Fatalf("Failed to read root dir: %v", err)
+	}
+	if len(des) == 0 {
+		t.Fatal("expected at least one entry in root dir")
+	}
+
+	for _, de := range des {
+		fi, err := de.Info()
+		if err != nil {
+			t.Fatalf("getting info for %s failed: %v", de.Name(), err)
+		}
+		sys, ok := fi.Sys().(squashfs.FileStat)
+		if !ok {
+			t.Fatalf("%s: Sys() did not return squashfs.FileStat", fi.Name())
+		}
+		if sys.Inode() == 0 {
+			t.Errorf("%s: expected non-zero Inode()", fi.Name())
+		}
+
+		typ := sys.InodeType()
+		switch typ {
+		case "basic-directory", "basic-file", "basic-symlink",
+			"basic-block-device", "basic-char-device", "basic-fifo", "basic-socket",
+			"extended-directory", "extended-file", "extended-symlink",
+			"extended-block-device", "extended-char-device", "extended-fifo", "extended-socket":
+			// ok
+		default:
+			t.Errorf("%s: unexpected InodeType() %q", fi.Name(), typ)
+		}
+
+		// Sanity check: directories should report a directory type
+		if fi.IsDir() && typ != "basic-directory" && typ != "extended-directory" {
+			t.Errorf("%s: directory has InodeType %q", fi.Name(), typ)
+		}
+	}
+
+	// Verify Stat-style access via OpenFile -> Stat too
+	fh, err := fs.OpenFile("README.md", os.O_RDONLY)
+	if err != nil {
+		t.Fatalf("OpenFile(README.md) failed: %v", err)
+	}
+	defer fh.Close()
+	fi, err := fh.Stat()
+	if err != nil {
+		t.Fatalf("Stat() failed: %v", err)
+	}
+	sys, ok := fi.Sys().(squashfs.FileStat)
+	if !ok {
+		t.Fatal("Sys() did not return squashfs.FileStat from Stat()")
+	}
+	if sys.Inode() == 0 {
+		t.Error("README.md: expected non-zero Inode() from Stat()")
+	}
+	if sys.InodeType() != "basic-file" && sys.InodeType() != "extended-file" {
+		t.Errorf("README.md: unexpected InodeType %q", sys.InodeType())
+	}
+}
+
 func TestSquashfsReadDirXattr(t *testing.T) {
 	fs, err := getValidSquashfsFSReadOnly()
 	if err != nil {


### PR DESCRIPTION
Refs #301. Sibling of #393 (ext4) — same goal, but adapted to squashfs's existing public surface.

## What this does

The other filesystems answering #301 (ext4, iso9660, fat) introduce a per-package `StatT` struct returned by `Sys()`. Squashfs is different: `Sys()` already returns `*directoryEntry` (aliased as the public `squashfs.FileStat`), which already exposes filesystem-specific metadata via accessor methods — `UID()`, `GID()`, `Xattrs()`, `Readlink()`.

To stay consistent with that existing public surface — and to avoid breaking any caller already doing `sys.(squashfs.FileStat).UID()` — this PR adds two more accessors rather than introducing a parallel struct:

- `(*directoryEntry).Inode() uint32` — squashfs inode number
- `(*directoryEntry).InodeType() string` — human-readable inode type (`"basic-file"`, `"extended-symlink"`, etc., one of 14 values)

`Sys()`'s return type is unchanged. Callers use it the same way they already use `UID()`/`GID()`:

```go
if st, ok := fi.Sys().(squashfs.FileStat); ok {
    fmt.Println(st.Inode(), st.InodeType(), st.UID())
}
```

### Why not a `StatT` struct here

Two competing public shapes inside one package (`squashfs.FileStat` accessor methods + `squashfs.StatT` struct fields, both reachable from the same `Sys()` call) would be worse than mild inconsistency across packages. The existing pattern was set when squashfs first exposed UID/GID/Xattrs; this PR follows it.

### Tests

New `TestSquashfsInodeMetadata` exercises `ReadDir(".")` + `DirEntry.Info()` and `OpenFile().Stat()` on the existing test image, asserts non-zero `Inode()`, no duplicate inode numbers across entries, and a sensible `InodeType()` (with the extra check that directories report `basic-directory` or `extended-directory`).