### PR TITLE
fat12/16/32: expose attribute flags and timestamps via FileInfo.Sys()

### DIFF
--- a/filesystem/fat12/directoryentry.go
+++ b/filesystem/fat12/directoryentry.go
@@ -55,7 +55,21 @@ func (de *directoryEntry) Info() (iofs.FileInfo, error) {
 		shortName: de.fullShortName(),
 		size:      int64(de.fileSize),
 		isDir:     de.isSubdirectory,
+		sys:       de.stat(),
 	}, nil
+}
+
+func (de *directoryEntry) stat() *StatT {
+	return &StatT{
+		ReadOnly:    de.isReadOnly,
+		Hidden:      de.isHidden,
+		System:      de.isSystem,
+		Archive:     de.isArchiveDirty,
+		VolumeLabel: de.isVolumeLabel,
+		CreateTime:  de.createTime,
+		AccessTime:  de.accessTime,
+		Cluster:     de.clusterLocation,
+	}
 }
 
 func (de *directoryEntry) nameMatches(name string) bool {

--- a/filesystem/fat12/fat12_test.go
+++ b/filesystem/fat12/fat12_test.go
@@ -408,6 +408,32 @@ func TestFat12Stat(t *testing.T) {
 	}
 }
 
+func TestFat12StatSys(t *testing.T) {
+	_, fs := createFAT12(t, "SYSTEST")
+	writeFile(t, fs, "/sys.txt", []byte("sys"))
+
+	info, err := fs.Stat("sys.txt")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	stat, ok := info.Sys().(*fat12.StatT)
+	if !ok {
+		t.Fatalf("Sys() did not return *fat12.StatT, got %T", info.Sys())
+	}
+	if stat == nil {
+		t.Fatal("StatT is nil")
+	}
+	if stat.Cluster < 2 {
+		t.Errorf("Cluster = %d, expected >= 2 (data clusters start at 2)", stat.Cluster)
+	}
+	if stat.VolumeLabel {
+		t.Error("regular file should not have VolumeLabel set")
+	}
+	if stat.Hidden || stat.System || stat.ReadOnly {
+		t.Errorf("unexpected attribute bits set: Hidden=%v System=%v ReadOnly=%v", stat.Hidden, stat.System, stat.ReadOnly)
+	}
+}
+
 // ── ReadFile (fs.ReadFileFS) ──────────────────────────────────────────────────
 
 func TestFat12ReadFile(t *testing.T) {

--- a/filesystem/fat12/file.go
+++ b/filesystem/fat12/file.go
@@ -30,6 +30,7 @@ func (fl *File) Stat() (iofs.FileInfo, error) {
 		shortName: fl.fullShortName(),
 		size:      int64(fl.fileSize),
 		isDir:     fl.isSubdirectory,
+		sys:       fl.stat(),
 	}, nil
 }
 

--- a/filesystem/fat12/fileinfo.go
+++ b/filesystem/fat12/fileinfo.go
@@ -14,6 +14,21 @@ type FileInfo struct {
 	shortName string
 	size      int64
 	isDir     bool
+	sys       *StatT
+}
+
+// StatT carries FAT-specific metadata returned by FileInfo.Sys(). FAT12/16/32
+// have no inodes, uid/gid, or POSIX permissions, but they do carry attribute
+// flags and additional timestamps that os.FileMode doesn't represent.
+type StatT struct {
+	ReadOnly    bool
+	Hidden      bool
+	System      bool
+	Archive     bool
+	VolumeLabel bool
+	CreateTime  time.Time
+	AccessTime  time.Time
+	Cluster     uint32
 }
 
 // IsDir abbreviation for Mode().IsDir()
@@ -63,9 +78,9 @@ func (fi FileInfo) Size() int64 {
 	return fi.size
 }
 
-// Sys underlying data source - not supported yet and so will return nil
+// Sys returns *StatT with FAT-specific metadata.
 //
 //nolint:gocritic // we need this to comply with fs.FileInfo
 func (fi FileInfo) Sys() interface{} {
-	return nil
+	return fi.sys
 }

--- a/filesystem/fat16/fat16.go
+++ b/filesystem/fat16/fat16.go
@@ -20,6 +20,9 @@ type FileSystem struct {
 // interface guard
 var _ filesystem.FileSystem = (*FileSystem)(nil)
 
+// StatT is an alias for fat12.StatT, the metadata returned by FileInfo.Sys().
+type StatT = fat12.StatT
+
 // Type returns filesystem.TypeFat16, overriding fat12.FileSystem.Type().
 func (fs *FileSystem) Type() filesystem.Type { return filesystem.TypeFat16 }
 

--- a/filesystem/fat32/fat32.go
+++ b/filesystem/fat32/fat32.go
@@ -28,6 +28,9 @@ const (
 // is directly usable in fat12.Dos20BPB struct literals.
 type SectorSize = fat12.SectorSize
 
+// StatT is an alias for fat12.StatT, the metadata returned by FileInfo.Sys().
+type StatT = fat12.StatT
+
 const (
 	SectorSize512        SectorSize = 512
 	SectorSize4096       SectorSize = 4096


### PR DESCRIPTION
Refs #301. Sibling of #393 (ext4) — same pattern, applied to all three FAT variants in a single change by leveraging the recent FAT12/16 refactor.

## What this does

`FileInfo.Sys()` previously returned `nil` for fat12, fat16, and fat32. FAT has no inodes / uid / gid / POSIX permissions — that's a format limit, not a code one — but the directory entry does carry metadata that doesn't fit `os.FileMode`:

- Attribute bits: read-only, hidden, system, archive (dirty), volume-label
- Two extra timestamps: creation (full resolution) and last access (date-only)
- The starting cluster of the file's chain

This PR introduces `fat12.StatT` carrying those fields, wires `fat12.FileInfo.Sys()` to return it, and exposes the same type from `fat32` and `fat16` via type aliases.

### Why this lives in fat12 (not three separate copies)

The upstream FAT12/16 support PR (#358) restructured the FAT codebase: the implementation lives in `filesystem/fat12`, and `filesystem/fat32` + `filesystem/fat16` are thin wrappers that embed `*fat12.FileSystem` and override `Type()`. Public API parity with the old fat32 surface is preserved through type aliases — `type SectorSize = fat12.SectorSize` already exists in `fat32.go`.

This PR follows that same pattern for `StatT`:

```go
// filesystem/fat12/fileinfo.go — single source of truth
type StatT struct { ReadOnly, Hidden, System, Archive, VolumeLabel bool; CreateTime, AccessTime time.Time; Cluster uint32 }

// filesystem/fat32/fat32.go — re-export
type StatT = fat12.StatT

// filesystem/fat16/fat16.go — re-export
type StatT = fat12.StatT
```

Concrete benefits:

1. **One implementation, three packages covered.** The `directoryEntry.stat()` helper that builds the `StatT` is defined once in `fat12`. fat16 and fat32 inherit the populated `Sys()` automatically.
2. **Callers keep their natural import.** Someone using `fat32` writes `fi.Sys().(*fat32.StatT)` and it works; someone using `fat12` writes `fi.Sys().(*fat12.StatT)` and it works. They get the same `*StatT` value because the types are aliases (not separate types with the same field shape) — so a downstream library that wants to handle any FAT variant can type-assert once against `*fat12.StatT` and it'll match all three.
3. **No drift risk.** If FAT16 later needs a new attribute exposed, it goes in `fat12.StatT` and the other two get it for free. The alternative — three separate `StatT` structs — would inevitably diverge.
4. **Mirrors the upstream architectural choice.** `fat16`/`fat32` are already wrappers around `fat12.FileSystem`; their public types are already aliases. Adding `StatT` as an alias is consistent with `SectorSize`, not a new pattern.

### Fields

All populated from data `parseDirEntries` already extracts today; no new parsing.

| Field | Source |
|---|---|
| `ReadOnly bool` | `directoryEntry.isReadOnly` |
| `Hidden bool` | `directoryEntry.isHidden` |
| `System bool` | `directoryEntry.isSystem` |
| `Archive bool` | `directoryEntry.isArchiveDirty` |
| `VolumeLabel bool` | `directoryEntry.isVolumeLabel` |
| `CreateTime time.Time` | `directoryEntry.createTime` |
| `AccessTime time.Time` | `directoryEntry.accessTime` (date-only per FAT spec) |
| `Cluster uint32` | `directoryEntry.clusterLocation` |

### Tests

New `TestFat12StatSys` writes a file to a freshly-created FAT12 image, asserts `Sys()` returns `*fat12.StatT`, `Cluster >= 2` (data clusters start at 2), `VolumeLabel == false`, and that no unexpected attribute bits are set on a regular file. Coverage extends to fat16/fat32 automatically because they reuse the same `directoryEntry.Info()` and `File.Stat()` code paths.