### PR TITLE
add stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,17 @@
+name: "Close stale issues and PRs"
+on:
+    schedule:
+        - cron: "30 1 * * *" # Runs every day at 1:30 AM UTC
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v10
+              with:
+                  stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+                  stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+                  close-issue-message: "This issue was closed because it has been stale for 5 days with no activity."
+                  close-pr-message: "This pull request was closed because it has been stale for 5 days with no activity."
+                  days-before-stale: 30
+                  days-before-close: 5


### PR DESCRIPTION
Automatically mark issues and PRs not touched for 30 days as stale, and stale issues not updated for 5 days as closed.