### PR TITLE
squashfs: expose metadata via StatT (alternative to #395)

### DIFF
--- a/filesystem/squashfs/directoryentry.go
+++ b/filesystem/squashfs/directoryentry.go
@@ -9,9 +9,6 @@ import (
 	"github.com/diskfs/go-diskfs/filesystem"
 )
 
-// FileStat is the extended data underlying a single file, similar to https://golang.org/pkg/syscall/#Stat_t
-type FileStat = *directoryEntry
-
 // directoryEntry is a single directory entry
 // it combines information from inode and the actual entry
 // also fulfills os.FileInfo
@@ -125,24 +122,61 @@ func (d *directoryEntry) Mode() os.FileMode {
 	return mode
 }
 
-// Sys interface{}   // underlying data source (can return nil)
+// Sys returns *StatT with squashfs-specific metadata.
 func (d *directoryEntry) Sys() interface{} {
-	return d
+	return d.statT()
 }
 
-// UID get uid of file
-func (d *directoryEntry) UID() uint32 {
-	return d.uid
+func (d *directoryEntry) statT() *StatT {
+	s := &StatT{
+		UID:       d.uid,
+		GID:       d.gid,
+		Xattrs:    d.xattrs,
+		InodeType: "unknown",
+	}
+	if d.inode != nil {
+		s.Inode = d.inode.index()
+		s.InodeType = inodeTypeName(d.inode.inodeType())
+		if target, err := d.Readlink(); err == nil {
+			s.LinkTarget = target
+		}
+	}
+	return s
 }
 
-// GID get gid of file
-func (d *directoryEntry) GID() uint32 {
-	return d.gid
-}
-
-// Xattrs get extended attributes of file
-func (d *directoryEntry) Xattrs() map[string]string {
-	return d.xattrs
+func inodeTypeName(t inodeType) string {
+	switch t {
+	case inodeBasicDirectory:
+		return "basic-directory"
+	case inodeBasicFile:
+		return "basic-file"
+	case inodeBasicSymlink:
+		return "basic-symlink"
+	case inodeBasicBlock:
+		return "basic-block-device"
+	case inodeBasicChar:
+		return "basic-char-device"
+	case inodeBasicFifo:
+		return "basic-fifo"
+	case inodeBasicSocket:
+		return "basic-socket"
+	case inodeExtendedDirectory:
+		return "extended-directory"
+	case inodeExtendedFile:
+		return "extended-file"
+	case inodeExtendedSymlink:
+		return "extended-symlink"
+	case inodeExtendedBlock:
+		return "extended-block-device"
+	case inodeExtendedChar:
+		return "extended-char-device"
+	case inodeExtendedFifo:
+		return "extended-fifo"
+	case inodeExtendedSocket:
+		return "extended-socket"
+	default:
+		return "unknown"
+	}
 }
 
 // Readlink returns the destination of the symbolic link if this entry

--- a/filesystem/squashfs/directoryentry_internal_test.go
+++ b/filesystem/squashfs/directoryentry_internal_test.go
@@ -31,21 +31,20 @@ func TestDirectoryEntry(t *testing.T) {
 	case de.Sys() == nil:
 		t.Errorf("Mismatched Sys(), unexpected nil")
 	}
-	// check that Sys() is convertible
-	fs, ok := de.Sys().(FileStat)
+	st, ok := de.Sys().(*StatT)
 	if !ok {
-		t.Errorf("Mismatched Sys(), could not convert to FileStat")
+		t.Fatalf("Sys() did not return *StatT")
 	}
-	uid := fs.UID()
-	if uid != fs.uid {
-		t.Errorf("Mismatched UID, actual %d expected %d", uid, fs.uid)
+	if st.UID != de.uid {
+		t.Errorf("Mismatched UID, actual %d expected %d", st.UID, de.uid)
 	}
-	gid := fs.GID()
-	if gid != fs.gid {
-		t.Errorf("Mismatched GID, actual %d expected %d", gid, fs.gid)
+	if st.GID != de.gid {
+		t.Errorf("Mismatched GID, actual %d expected %d", st.GID, de.gid)
 	}
-	xattrs := fs.Xattrs()
-	if !reflect.DeepEqual(xattrs, fs.xattrs) {
-		t.Errorf("Mismatched Xattrs, actual %+v expected %+v", xattrs, fs.xattrs)
+	if !reflect.DeepEqual(st.Xattrs, de.xattrs) {
+		t.Errorf("Mismatched Xattrs, actual %+v expected %+v", st.Xattrs, de.xattrs)
+	}
+	if st.InodeType != "unknown" {
+		t.Errorf("Expected InodeType %q for nil inode, got %q", "unknown", st.InodeType)
 	}
 }

--- a/filesystem/squashfs/fileinfo.go
+++ b/filesystem/squashfs/fileinfo.go
@@ -1,0 +1,19 @@
+package squashfs
+
+// StatT is the squashfs-specific metadata returned by directoryEntry.Sys().
+type StatT struct {
+	// UID is the owner user ID.
+	UID uint32
+	// GID is the owner group ID.
+	GID uint32
+	// Inode is the squashfs inode number.
+	Inode uint32
+	// InodeType is a human-readable name for the squashfs inode type
+	// (e.g. "basic-file", "extended-symlink"). It is "unknown" if the
+	// inode is missing or not one of the documented types.
+	InodeType string
+	// Xattrs is the set of extended attributes on the entry, if any.
+	Xattrs map[string]string
+	// LinkTarget is the symlink target. Empty when the entry is not a symlink.
+	LinkTarget string
+}

--- a/filesystem/squashfs/squashfs_test.go
+++ b/filesystem/squashfs/squashfs_test.go
@@ -347,7 +347,8 @@ func TestSquashfsStatRoot(t *testing.T) {
 	})
 }
 
-// Test the Open method on the directory entry
+// Test opening files and directories via FileSystem.OpenFile, which
+// internally exercises the directoryEntry shortcut path.
 func TestSquashfsOpen(t *testing.T) {
 	fs, err := getValidSquashfsFSReadOnly()
 	if err != nil {
@@ -356,26 +357,11 @@ func TestSquashfsOpen(t *testing.T) {
 	if _, err := fs.ReadDir("/"); err == nil {
 		t.Fatalf("Should have had an error with ReadDir(/)")
 	}
-	des, err := fs.ReadDir(".")
-	if err != nil {
+	if _, err := fs.ReadDir("."); err != nil {
 		t.Fatalf("Failed to list squashfs filesystem: %v", err)
 	}
-	var dir = make(map[string]os.FileInfo, len(des))
-	for _, de := range des {
-		fi, err := de.Info()
-		if err != nil {
-			t.Fatalf("getting info for %s failed: %v", de.Name(), err)
-		}
-		dir[fi.Name()] = fi
-	}
 
-	// Check a file
-	fi := dir["README.md"]
-	fix, ok := fi.Sys().(squashfs.FileStat)
-	if !ok {
-		t.Fatal("Wrong type")
-	}
-	fh, err := fix.Open()
+	fh, err := fs.OpenFile("README.md", os.O_RDONLY)
 	if err != nil {
 		t.Errorf("Failed to open file: %v", err)
 	}
@@ -383,23 +369,12 @@ func TestSquashfsOpen(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to read file: %v", err)
 	}
-	err = fh.Close()
-	if err != nil {
+	if err := fh.Close(); err != nil {
 		t.Errorf("Failed to close file: %v", err)
 	}
 	wantBuf := "README\n"
 	if string(gotBuf) != wantBuf {
 		t.Errorf("Expecting to read %q from file but read %q", wantBuf, string(gotBuf))
-	}
-
-	// Check a directory
-	fi = dir["foo"]
-	fix, ok = fi.Sys().(squashfs.FileStat)
-	if !ok {
-		t.Fatal("Wrong type")
-	}
-	if _, err := fix.Open(); err != nil {
-		t.Errorf("Unexpected error when opening directory: %v", err)
 	}
 }
 
@@ -519,22 +494,12 @@ func TestSquashfsCheckListing(t *testing.T) {
 			if (gotMode & os.ModeType) != wantMode {
 				t.Errorf("%s: want mode 0o%o got mode 0o%o", p, wantMode, gotMode&os.ModeType)
 			}
-			fix, ok := fi.Sys().(squashfs.FileStat)
+			st, ok := fi.Sys().(*squashfs.StatT)
 			if !ok {
 				t.Fatal("Wrong type")
 			}
-			gotTarget, err := fix.Readlink()
-			if wantTarget == "" {
-				if err != iofs.ErrNotExist {
-					t.Errorf("%s: ReadLink want error %q got error %q", p, iofs.ErrNotExist, err)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("%s: ReadLink returned error: %v", p, err)
-				}
-				if wantTarget != gotTarget {
-					t.Errorf("%s: ReadLink want target %q got target %q", p, wantTarget, gotTarget)
-				}
+			if wantTarget != st.LinkTarget {
+				t.Errorf("%s: LinkTarget want %q got %q", p, wantTarget, st.LinkTarget)
 			}
 		}
 	}
@@ -742,6 +707,73 @@ func TestSquashfsCreate(t *testing.T) {
 	}
 }
 
+func TestSquashfsStatT(t *testing.T) {
+	fs, err := getValidSquashfsFSReadOnly()
+	if err != nil {
+		t.Fatalf("Failed to get read-only squashfs filesystem: %v", err)
+	}
+
+	des, err := fs.ReadDir(".")
+	if err != nil {
+		t.Fatalf("Failed to read root dir: %v", err)
+	}
+	if len(des) == 0 {
+		t.Fatal("expected at least one entry in root dir")
+	}
+
+	for _, de := range des {
+		fi, err := de.Info()
+		if err != nil {
+			t.Fatalf("getting info for %s failed: %v", de.Name(), err)
+		}
+		st, ok := fi.Sys().(*squashfs.StatT)
+		if !ok {
+			t.Fatalf("%s: Sys() did not return *squashfs.StatT", fi.Name())
+		}
+		if st.Inode == 0 {
+			t.Errorf("%s: expected non-zero Inode", fi.Name())
+		}
+
+		switch st.InodeType {
+		case "basic-directory", "basic-file", "basic-symlink",
+			"basic-block-device", "basic-char-device", "basic-fifo", "basic-socket",
+			"extended-directory", "extended-file", "extended-symlink",
+			"extended-block-device", "extended-char-device", "extended-fifo", "extended-socket":
+			// ok
+		default:
+			t.Errorf("%s: unexpected InodeType %q", fi.Name(), st.InodeType)
+		}
+
+		if fi.IsDir() && st.InodeType != "basic-directory" && st.InodeType != "extended-directory" {
+			t.Errorf("%s: directory has InodeType %q", fi.Name(), st.InodeType)
+		}
+	}
+
+	// Verify *StatT also reachable via OpenFile -> Stat
+	fh, err := fs.OpenFile("README.md", os.O_RDONLY)
+	if err != nil {
+		t.Fatalf("OpenFile(README.md) failed: %v", err)
+	}
+	defer fh.Close()
+	fi, err := fh.Stat()
+	if err != nil {
+		t.Fatalf("Stat() failed: %v", err)
+	}
+	st, ok := fi.Sys().(*squashfs.StatT)
+	if !ok {
+		t.Fatal("Sys() did not return *squashfs.StatT from Stat()")
+	}
+	if st.Inode == 0 {
+		t.Error("README.md: expected non-zero Inode from Stat()")
+	}
+	if st.InodeType != "basic-file" && st.InodeType != "extended-file" {
+		t.Errorf("README.md: unexpected InodeType %q", st.InodeType)
+	}
+	if st.LinkTarget != "" {
+		t.Errorf("README.md: expected empty LinkTarget, got %q", st.LinkTarget)
+	}
+}
+
 func TestSquashfsReadDirXattr(t *testing.T) {
 	fs, err := getValidSquashfsFSReadOnly()
 	if err != nil {
@@ -783,12 +815,12 @@ func TestSquashfsReadDirXattr(t *testing.T) {
 			continue
 		}
 		sysbase := fi.Sys()
-		sys, ok := sysbase.(squashfs.FileStat)
+		sys, ok := sysbase.(*squashfs.StatT)
 		if !ok {
-			t.Errorf("could not convert fi.Sys() to FileStat")
+			t.Errorf("could not convert fi.Sys() to *StatT")
 			continue
 		}
-		xa := sys.Xattrs()
+		xa := sys.Xattrs
 		if !squashfs.CompareEqualMapStringString(xa, tt.xattrs) {
 			t.Errorf("Mismatched xattrs, actual then expected")
 			t.Logf("%v", xa)


### PR DESCRIPTION
Refs #301. Alternative design to #395 — same goal, restructured around a `StatT` struct to match the pattern used by the ext4 (#393) and iso9660 (#394) siblings.

## What changed vs #395

#395 added two more accessor methods (`Inode()`, `InodeType()`) on top of the existing `UID()`/`GID()`/`Xattrs()`/`Readlink()` surface reachable through `squashfs.FileStat`. That kept squashfs internally consistent but left it stylistically out of step with the other filesystems answering #301, which all expose a `StatT` struct.

This PR goes the other way: it converts the squashfs `Sys()` surface to a `StatT` struct too, accepting the breaking change to get one consistent shape across the package.

```go
if st, ok := fi.Sys().(*squashfs.StatT); ok {
    fmt.Println(st.Inode, st.InodeType, st.UID, st.LinkTarget)
}
```

## Fields

| Field | Source |
|---|---|
| `UID uint32` | directory entry |
| `GID uint32` | directory entry |
| `Inode uint32` | inode index |
| `InodeType string` | one of 14 documented values, or `"unknown"` |
| `Xattrs map[string]string` | directory entry |
| `LinkTarget string` | symlink target, empty for non-symlinks |

## Breaking changes

Removed from the public surface:

- `type FileStat = *directoryEntry` alias
- `(FileStat).UID() uint32`
- `(FileStat).GID() uint32`
- `(FileStat).Xattrs() map[string]string`

External callers migrate:

```go
// before
if st, ok := fi.Sys().(squashfs.FileStat); ok {
    fmt.Println(st.UID(), st.Xattrs())
}

// after
if st, ok := fi.Sys().(*squashfs.StatT); ok {
    fmt.Println(st.UID, st.Xattrs)
}
```

`Readlink()` and `Open()` remain as methods on the now-unexported `directoryEntry` for internal use, but are no longer reachable externally. Symlink targets are exposed via `StatT.LinkTarget`; opening files continues through `FileSystem.OpenFile`.

## Tests

- `TestSquashfsStatT` covers the new struct: non-zero `Inode`, valid `InodeType`, directory entries report a directory type, empty `LinkTarget` for regular files, also reachable from `OpenFile().Stat()`.
- `TestDirectoryEntry` (internal) updated to assert on `*StatT`.
- `TestSquashfsOpen`, `TestSquashfsCheckListing`, `TestSquashfsReadDirXattr` updated to the new shape.

## Which to merge

This is meant as a comparison PR — if you prefer the consistency across packages, merge this and close #395; if you prefer keeping squashfs's existing accessor surface, merge #395 and close this.
