### PR TITLE
fat32: make corruption test deterministic

### DIFF
--- a/filesystem/fat32/fat32_test.go
+++ b/filesystem/fat32/fat32_test.go
@@ -614,8 +614,14 @@ func TestFat32Read(t *testing.T) {
 				// make any changes needed to corrupt it
 				corrupted := ""
 				if tt.bytechange >= 0 {
+					// Flip every bit of the target byte. Writing a random
+					// byte here could reproduce the original value (~1/256),
+					// leaving the sector valid and the negative test flaky.
 					b := make([]byte, 1)
-					_, _ = rand.Read(b)
+					if _, err := f.ReadAt(b, tt.bytechange+pre); err != nil {
+						t.Fatal(err)
+					}
+					b[0] ^= 0xff
 					_, _ = f.WriteAt(b, tt.bytechange+pre)
 					corrupted = fmt.Sprintf("corrupted %d", tt.bytechange+pre)
 				}


### PR DESCRIPTION
## Summary

`TestFat32Read`'s negative case corrupts the FAT32 FSInfo sector and
expects `Read` to reject it. It did so by writing a single **random**
byte at the sector's start-signature offset (`0x52526141`, so the byte
should be `0x52`). About one run in 256 the random byte equals the
original value, leaving the signature valid — `Read` returns no error
and the test fails with:

```
fat32_test.go:628: ... corrupted 512: mismatched errors, actual <nil>
expected error reading FileSystem Information Sector
```

This flake is independent of any production code; it surfaces
intermittently across PRs (e.g. a recent CI run on #407).

## Fix

Flip the bits of the existing byte (`b[0] ^= 0xff`) instead of writing a
random one, so the corruption always differs from the original and the
test is deterministic. Verified with `go test -run TestFat32Read
-count=200` (previously flaky, now consistently green).
