### PR TITLE
fix FSIS corruption test

### DIFF
--- a/filesystem/fat32/fat32_test.go
+++ b/filesystem/fat32/fat32_test.go
@@ -615,7 +615,10 @@ func TestFat32Read(t *testing.T) {
 				corrupted := ""
 				if tt.bytechange >= 0 {
 					b := make([]byte, 1)
-					_, _ = rand.Read(b)
+					f.ReadAt(b, tt.bytechange+pre)
+					// corrupt by adding exactly 10, rather than random, which might turn
+					// out to be the original value that was there
+					b[0] += 10
 					_, _ = f.WriteAt(b, tt.bytechange+pre)
 					corrupted = fmt.Sprintf("corrupted %d", tt.bytechange+pre)
 				}


### PR DESCRIPTION
Thanks to @eriknordmark for finding it and commenting [here](https://github.com/diskfs/go-diskfs/pull/407#issuecomment-4650487324).

In short, in fat32 corruption tests, we replace a specific byte with a random one. Once in a while, that random one might be the same as the original, so nothing gets changed. This tests changes it instead to read the original one, and just add 10 and write it back.