### PR TITLE
sync: skip excluded paths in CompareFS

### DIFF
--- a/sync/verify.go
+++ b/sync/verify.go
@@ -69,6 +69,15 @@ func CompareFS(origFS, targetFS fs.FS) error {
 		if err != nil {
 			return err
 		}
+		// Skip the same entries CopyFileSystem skips (lost+found, etc.):
+		// the copy never writes them to the target, so requiring them here
+		// would always fail. Match on basename, exactly as the copy does.
+		if excludedPaths[path.Base(p)] {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
 		seen[p] = struct{}{}
 
 		// Check existence in target FS
@@ -103,11 +112,18 @@ func CompareFS(origFS, targetFS fs.FS) error {
 	}
 
 	// Ensure target FS has no extra files
-	//
-	//nolint:revive // keeping args for clarity of intent.
 	return fs.WalkDir(targetFS, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		// Excluded entries were never added to seen above, so skip them here
+		// too; otherwise a target that legitimately has its own lost+found
+		// (e.g. one created by mke2fs) would be flagged as an extra path.
+		if excludedPaths[path.Base(p)] {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
 		}
 		if _, ok := seen[p]; !ok {
 			return fmt.Errorf("extra path %q in target FS", p)

--- a/sync/verify_test.go
+++ b/sync/verify_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"io/fs"
 	"testing"
 	"testing/fstest"
 )
@@ -52,6 +53,45 @@ func TestCompareFS(t *testing.T) {
 				"extra.txt": {Data: []byte("extra")},
 			},
 			wantErr: true,
+		},
+		{
+			// CopyFileSystem excludes lost+found, so a source that has one
+			// (e.g. created by mke2fs) must not be required in the target.
+			name: "excluded lost+found in source only",
+			origFS: fstest.MapFS{
+				"file.txt":            {Data: []byte("hello")},
+				"lost+found":          {Mode: fs.ModeDir},
+				"lost+found/#1234567": {Data: []byte("orphan")},
+			},
+			targetFS: fstest.MapFS{
+				"file.txt": {Data: []byte("hello")},
+			},
+			wantErr: false,
+		},
+		{
+			// Symmetric case: a target with its own lost+found must not be
+			// reported as having an extra path.
+			name: "excluded lost+found in target only",
+			origFS: fstest.MapFS{
+				"file.txt": {Data: []byte("hello")},
+			},
+			targetFS: fstest.MapFS{
+				"file.txt":   {Data: []byte("hello")},
+				"lost+found": {Mode: fs.ModeDir},
+			},
+			wantErr: false,
+		},
+		{
+			// The exclusion covers the whole list, not just lost+found.
+			name: "excluded .DS_Store in source only",
+			origFS: fstest.MapFS{
+				"file.txt":  {Data: []byte("hello")},
+				".DS_Store": {Data: []byte("mac metadata")},
+			},
+			targetFS: fstest.MapFS{
+				"file.txt": {Data: []byte("hello")},
+			},
+			wantErr: false,
 		},
 		{
 			name: "directory vs file mismatch",


### PR DESCRIPTION
## Problem

`CopyFileSystem` deliberately skips a small set of names — `lost+found`,
`.DS_Store`, `System Volume Information` — via its `excludedPaths` map, so
they are never written to the target. `CompareFS`, however, walked the
source and required *every* entry to also exist in the target, with no
such exclusion.

The two halves of the `sync` package therefore contradict each other:
verifying a faithful copy of any filesystem that contains a `lost+found`
(which every `mke2fs`-created ext4 does) fails with
`path "lost+found" missing in target FS`, even though the copy behaved
exactly as designed. The same latent failure exists for `.DS_Store` and
`System Volume Information`.

## Fix

Apply the same basename-based exclusion in both directions of `CompareFS`:
skip excluded entries (and their subtrees, via `fs.SkipDir`) when checking
that the source is present in the target, and again when scanning the
target for extra paths — so a target that has its own `lost+found` is not
reported as an extra path.

## Testing

`go test ./sync/...` passes. Added table cases to `TestCompareFS` covering
an excluded entry present only in the source, only in the target, and a
non-`lost+found` excluded name (`.DS_Store`); each fails before this change
with the exact `missing in target FS` / `extra path` signature and passes
after.

Verified end-to-end against the downstream consumer (partitionresizer): its
ext4 grow path creates a fresh target with `CreateFilesystem`, copies with
`CopyFileSystem`, then verifies with `CompareFS`; that verification
previously failed on `lost+found` and now succeeds.
