### PR TITLE
backend,disk: make partition ops work on busy block devices

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -28,6 +28,17 @@ func New(f fs.File, readOnly bool) backend.Storage {
 // Should pass a path to a block device e.g. /dev/sda or a path to a file /tmp/foo.img
 // The provided device/file must exist at the time you call OpenFromPath()
 func OpenFromPath(pathName string, readOnly bool) (backend.Storage, error) {
+	return OpenFromPathWithExclusive(pathName, readOnly, true)
+}
+
+// OpenFromPathWithExclusive is like OpenFromPath but lets the caller choose
+// whether a writable open uses O_EXCL. The exclusive flag is ignored for a
+// read-only open. Callers that shell out to filesystem utilities
+// (e.g. e2fsck/resize2fs) on the child partitions of a whole disk must open the
+// disk non-exclusively: holding the parent disk O_EXCL makes the kernel reject
+// O_EXCL opens of its partitions ("device is in use"). The returned backend
+// records the path, unlike New.
+func OpenFromPathWithExclusive(pathName string, readOnly, exclusive bool) (backend.Storage, error) {
 	if pathName == "" {
 		return nil, errors.New("must pass device of file name")
 	}
@@ -39,7 +50,10 @@ func OpenFromPath(pathName string, readOnly bool) (backend.Storage, error) {
 	openMode := os.O_RDONLY
 
 	if !readOnly {
-		openMode |= os.O_RDWR | os.O_EXCL
+		openMode |= os.O_RDWR
+		if exclusive {
+			openMode |= os.O_EXCL
+		}
 	}
 
 	f, err := os.OpenFile(pathName, openMode, 0o600)

--- a/disk/disk.go
+++ b/disk/disk.go
@@ -22,6 +22,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ErrReReadDeferred is returned (wrapped) by ReReadPartitionTable when the
+// on-disk partition table was written successfully but the kernel could not be
+// made to re-read it because the disk is busy (a partition is mounted/held — the
+// common case when repartitioning the disk you are booted from). The new table
+// is committed on disk; a reboot makes the kernel pick it up. Callers can detect
+// this with errors.Is and reboot-to-apply instead of treating it as a failure.
+var ErrReReadDeferred = errors.New("partition table written to disk but kernel re-read deferred (device busy); reboot to apply")
+
 // Disk is a reference to a single disk block device or image that has been Create() or Open()
 type Disk struct {
 	Backend           backend.Storage

--- a/disk/disk_blkpg_linux.go
+++ b/disk/disk_blkpg_linux.go
@@ -1,0 +1,150 @@
+//go:build linux
+
+package disk
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	blkpg = 0x1269
+
+	blkpgAddPartition = 1
+	blkpgDelPartition = 2
+
+	blkpgDevNameLth = 64
+)
+
+// blkpgPartition mirrors the kernel's struct blkpg_partition (linux/blkpg.h):
+// start and length are in bytes, pno is the partition number.
+type blkpgPartition struct {
+	start   int64
+	length  int64
+	pno     int32
+	devname [blkpgDevNameLth]byte
+	volname [blkpgDevNameLth]byte
+}
+
+// blkpgIoctlArg mirrors the kernel's struct blkpg_ioctl_arg. The explicit
+// padding aligns the data pointer to an 8-byte boundary, matching the C layout
+// on 64-bit platforms.
+type blkpgIoctlArg struct {
+	op      int32
+	flags   int32
+	datalen int32
+	_       int32
+	data    unsafe.Pointer
+}
+
+// reconcilePartitionsBLKPG brings the kernel's partition list in line with the
+// table go-diskfs just wrote, touching only the entries that actually changed so
+// that unrelated busy/mounted partitions are left alone.
+func (d *Disk) reconcilePartitionsBLKPG(fd int) error {
+	path := d.Backend.Path()
+	if path == "" {
+		return fmt.Errorf("backend has no path; cannot reconcile partitions")
+	}
+	existing, err := readKernelPartitions(filepath.Base(path))
+	if err != nil {
+		return err
+	}
+
+	// desired: partition number -> [startBytes, lengthBytes] from the table.
+	desired := make(map[int][2]int64)
+	if d.Table != nil {
+		for _, p := range d.Table.GetPartitions() {
+			desired[p.GetIndex()] = [2]int64{p.GetStart(), p.GetSize()}
+		}
+	}
+
+	// Delete kernel partitions that are gone, or whose geometry changed (a
+	// changed one is re-added below). Leave unchanged partitions untouched.
+	for pno, have := range existing {
+		if want, ok := desired[pno]; ok && want == have {
+			continue
+		}
+		if err := blkpgCall(fd, blkpgDelPartition, pno, 0, 0); err != nil {
+			return fmt.Errorf("del partition %d: %w", pno, err)
+		}
+		delete(existing, pno)
+	}
+
+	// Add partitions that are new or were just removed for a geometry change.
+	for pno, want := range desired {
+		if have, ok := existing[pno]; ok && have == want {
+			continue
+		}
+		if err := blkpgCall(fd, blkpgAddPartition, pno, want[0], want[1]); err != nil {
+			return fmt.Errorf("add partition %d: %w", pno, err)
+		}
+	}
+	return nil
+}
+
+// blkpgCall issues a single BLKPG add/delete for partition pno.
+func blkpgCall(fd, op, pno int, start, length int64) error {
+	part := blkpgPartition{start: start, length: length, pno: int32(pno)}
+	arg := blkpgIoctlArg{
+		op:      int32(op),
+		datalen: int32(unsafe.Sizeof(part)),
+		data:    unsafe.Pointer(&part),
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(blkpg), uintptr(unsafe.Pointer(&arg)))
+	// Deleting a partition the kernel never created is a no-op for our purpose.
+	if errno == unix.ENXIO && op == blkpgDelPartition {
+		return nil
+	}
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// readKernelPartitions returns the kernel's current view of the partitions on
+// the block device named base (e.g. "sda", "nbd0", "nvme0n1"), keyed by
+// partition number, with start and length in bytes. /sys reports start and size
+// in 512-byte sectors regardless of the device's logical sector size.
+func readKernelPartitions(base string) (map[int][2]int64, error) {
+	dir := "/sys/block/" + base
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int][2]int64)
+	for _, e := range entries {
+		pnoRaw, err := os.ReadFile(filepath.Join(dir, e.Name(), "partition"))
+		if err != nil {
+			continue // not a partition subdirectory
+		}
+		pno, err := strconv.Atoi(strings.TrimSpace(string(pnoRaw)))
+		if err != nil {
+			continue
+		}
+		start := readSysSectors(filepath.Join(dir, e.Name(), "start"))
+		size := readSysSectors(filepath.Join(dir, e.Name(), "size"))
+		if start < 0 || size < 0 {
+			continue
+		}
+		out[pno] = [2]int64{start * 512, size * 512}
+	}
+	return out, nil
+}
+
+func readSysSectors(path string) int64 {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return -1
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return -1
+	}
+	return n
+}

--- a/disk/disk_blkpg_other.go
+++ b/disk/disk_blkpg_other.go
@@ -1,0 +1,13 @@
+//go:build (aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris) && !linux
+
+package disk
+
+import "fmt"
+
+// reconcilePartitionsBLKPG is a Linux-only mechanism: it relies on the BLKPG
+// ioctl and the /sys/block partition layout, neither of which exists on other
+// unix platforms. There is no portable fallback, so report that the re-read
+// could not be completed.
+func (d *Disk) reconcilePartitionsBLKPG(_ int) error {
+	return fmt.Errorf("BLKPG partition reconciliation is only supported on Linux")
+}

--- a/disk/disk_blockdev_linux_test.go
+++ b/disk/disk_blockdev_linux_test.go
@@ -1,0 +1,278 @@
+//go:build linux
+
+package disk_test
+
+// On-device regression test for the BLKPG re-read fallback added in
+// ReReadPartitionTable. The file-based tests cannot reach it: a regular file
+// has no kernel partition table to re-read, and BLKRRPART only fails (and the
+// fallback only fires) on a real block device whose partitions are in use.
+//
+// The test builds a GPT image, exposes it as a loop device, mounts one
+// partition so a whole-disk BLKRRPART is guaranteed to fail with EBUSY, then
+// rewrites the table to shrink a *different* partition and confirms the kernel
+// picked up the change via the per-partition BLKPG path while the mounted
+// sibling was left untouched. It requires root (losetup/mount) and is skipped
+// otherwise.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	diskfs "github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+	"golang.org/x/sys/unix"
+)
+
+// blkrrpart is the BLKRRPART ioctl (linux uapi/linux/fs.h); duplicated here
+// because the disk package keeps it unexported. Used only to assert the
+// precondition that a plain whole-disk re-read fails on the busy device.
+const blkrrpart = 0x125f
+
+const sectorBytes = 512
+
+func run(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func requireCmd(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not available: %v", name, err)
+	}
+}
+
+// readSysPartitions returns the kernel's view of base's partitions (e.g.
+// "loop7"), keyed by partition number, with start and size in bytes. /sys
+// reports both in 512-byte sectors regardless of logical sector size.
+func readSysPartitions(t *testing.T, base string) map[int][2]int64 {
+	t.Helper()
+	dir := "/sys/block/" + base
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	out := make(map[int][2]int64)
+	for _, e := range entries {
+		pnoRaw, err := os.ReadFile(filepath.Join(dir, e.Name(), "partition"))
+		if err != nil {
+			continue // not a partition subdirectory
+		}
+		pno, err := strconv.Atoi(strings.TrimSpace(string(pnoRaw)))
+		if err != nil {
+			continue
+		}
+		start := readSysInt(t, filepath.Join(dir, e.Name(), "start"))
+		size := readSysInt(t, filepath.Join(dir, e.Name(), "size"))
+		out[pno] = [2]int64{start * sectorBytes, size * sectorBytes}
+	}
+	return out
+}
+
+func readSysInt(t *testing.T, path string) int64 {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return n
+}
+
+func isMounted(t *testing.T, dev string) bool {
+	t.Helper()
+	b, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		t.Fatalf("read /proc/mounts: %v", err)
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if fields := strings.Fields(line); len(fields) > 0 && fields[0] == dev {
+			return true
+		}
+	}
+	return false
+}
+
+// mkPartition builds a GPT partition spanning [startSector, startSector+sectors).
+func mkPartition(index int, name string, startSector, sectors uint64) *gpt.Partition {
+	return &gpt.Partition{
+		Index: index,
+		Start: startSector,
+		End:   startSector + sectors - 1,
+		Size:  sectors * sectorBytes,
+		Type:  gpt.LinuxFilesystem,
+		Name:  name,
+	}
+}
+
+func TestReReadPartitionTableBLKPGFallback(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for losetup/mount")
+	}
+	requireCmd(t, "losetup")
+	requireCmd(t, "mkfs.ext4")
+	requireCmd(t, "mount")
+
+	tmp := t.TempDir()
+	imgPath := filepath.Join(tmp, "disk.img")
+
+	// 64 MiB image with two 8 MiB partitions: p1 (mounted, kept) and p2 (shrunk).
+	const (
+		diskSize     = int64(64 << 20)
+		p1Start      = uint64(2048)
+		eightMiBSecs = uint64(8 << 20 / sectorBytes) // 16384 sectors
+		fourMiBSecs  = uint64(4 << 20 / sectorBytes) // 8192 sectors
+		p2Start      = p1Start + eightMiBSecs
+	)
+	if f, err := os.Create(imgPath); err != nil {
+		t.Fatalf("create image: %v", err)
+	} else {
+		if err := f.Truncate(diskSize); err != nil {
+			t.Fatalf("truncate image: %v", err)
+		}
+		f.Close()
+	}
+
+	// Write the initial table to the file (regular file: ReReadPartitionTable
+	// inside Partition() is a no-op, so no fallback involved here).
+	initBk, err := file.OpenFromPathWithExclusive(imgPath, false, false)
+	if err != nil {
+		t.Fatalf("open image: %v", err)
+	}
+	dInit, err := diskfs.OpenBackend(initBk, diskfs.WithSectorSize(diskfs.SectorSize512))
+	if err != nil {
+		t.Fatalf("OpenBackend image: %v", err)
+	}
+	initTable := &gpt.Table{
+		LogicalSectorSize:  sectorBytes,
+		PhysicalSectorSize: sectorBytes,
+		ProtectiveMBR:      true,
+		Partitions: []*gpt.Partition{
+			mkPartition(1, "busy", p1Start, eightMiBSecs),
+			mkPartition(2, "resizeme", p2Start, eightMiBSecs),
+		},
+	}
+	if err := dInit.Partition(initTable); err != nil {
+		t.Fatalf("write initial table: %v", err)
+	}
+	if err := initBk.Close(); err != nil {
+		t.Fatalf("close image: %v", err)
+	}
+
+	// Expose as a loop device with partition scanning.
+	loopdev := run(t, "losetup", "--find", "--partscan", "--show", imgPath)
+	base := filepath.Base(loopdev)
+	t.Cleanup(func() {
+		// Detach only after every partition is unmounted (cleanup below runs first).
+		_ = exec.Command("losetup", "--detach", loopdev).Run()
+	})
+	// Best-effort wait for the partition device nodes.
+	if _, err := exec.LookPath("udevadm"); err == nil {
+		_ = exec.Command("udevadm", "settle").Run()
+	}
+
+	p1Dev := loopdev + "p1"
+	if _, err := os.Stat(p1Dev); err != nil {
+		t.Fatalf("partition node %s did not appear: %v", p1Dev, err)
+	}
+
+	// Make p1 busy by mounting an ext4 on it -- guarantees BLKRRPART EBUSY.
+	run(t, "mkfs.ext4", "-F", "-q", p1Dev)
+	mnt := filepath.Join(tmp, "mnt")
+	if err := os.Mkdir(mnt, 0o755); err != nil {
+		t.Fatalf("mkdir mnt: %v", err)
+	}
+	run(t, "mount", p1Dev, mnt)
+	t.Cleanup(func() { _ = exec.Command("umount", mnt).Run() })
+	if !isMounted(t, p1Dev) {
+		t.Fatalf("%s is not mounted; cannot guarantee the fallback path", p1Dev)
+	}
+
+	before := readSysPartitions(t, base)
+	if _, ok := before[1]; !ok {
+		t.Fatalf("kernel does not see partition 1 before resize: %v", before)
+	}
+	if _, ok := before[2]; !ok {
+		t.Fatalf("kernel does not see partition 2 before resize: %v", before)
+	}
+
+	// Precondition: a plain whole-disk BLKRRPART must fail while p1 is mounted,
+	// so the rewrite below is forced down the BLKPG fallback.
+	df, err := os.OpenFile(loopdev, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", loopdev, err)
+	}
+	if _, rrErr := unix.IoctlGetInt(int(df.Fd()), blkrrpart); rrErr == nil {
+		df.Close()
+		t.Fatalf("BLKRRPART unexpectedly succeeded with %s mounted; cannot validate the BLKPG fallback", p1Dev)
+	} else {
+		t.Logf("BLKRRPART failed as expected on busy device: %v", rrErr)
+	}
+	df.Close()
+
+	// Reopen the loop device the way the consumer does -- non-exclusive so the
+	// open coexists with the mounted partition -- and shrink p2 to 4 MiB while
+	// leaving p1 untouched.
+	bk, err := file.OpenFromPathWithExclusive(loopdev, false, false)
+	if err != nil {
+		t.Fatalf("open loop device: %v", err)
+	}
+	d, err := diskfs.OpenBackend(bk, diskfs.WithSectorSize(diskfs.SectorSize512))
+	if err != nil {
+		t.Fatalf("OpenBackend loop device: %v", err)
+	}
+	newTable := &gpt.Table{
+		LogicalSectorSize:  sectorBytes,
+		PhysicalSectorSize: sectorBytes,
+		ProtectiveMBR:      true,
+		Partitions: []*gpt.Partition{
+			mkPartition(1, "busy", p1Start, eightMiBSecs), // unchanged
+			mkPartition(2, "resizeme", p2Start, fourMiBSecs),
+		},
+	}
+	// Partition() writes the table and calls ReReadPartitionTable internally;
+	// with p1 mounted that re-read takes the BLKPG fallback. A nil error here is
+	// the fallback succeeding.
+	if err := d.Partition(newTable); err != nil {
+		t.Fatalf("Partition() on busy device failed (BLKPG fallback): %v", err)
+	}
+	if err := bk.Close(); err != nil {
+		t.Fatalf("close loop device: %v", err)
+	}
+
+	if _, err := exec.LookPath("udevadm"); err == nil {
+		_ = exec.Command("udevadm", "settle").Run()
+	}
+
+	after := readSysPartitions(t, base)
+
+	// p1 must be byte-for-byte unchanged and still mounted.
+	if after[1] != before[1] {
+		t.Errorf("partition 1 geometry changed: before=%v after=%v", before[1], after[1])
+	}
+	if !isMounted(t, p1Dev) {
+		t.Errorf("%s was unmounted by the re-read; the fallback disturbed an unchanged partition", p1Dev)
+	}
+
+	// p2 must reflect the new, smaller size at the same start.
+	wantStart := int64(p2Start) * sectorBytes
+	wantSize := int64(fourMiBSecs) * sectorBytes
+	if after[2][0] != wantStart {
+		t.Errorf("partition 2 start = %d, want %d", after[2][0], wantStart)
+	}
+	if after[2][1] != wantSize {
+		t.Errorf("partition 2 size = %d, want %d (kernel did not pick up the shrink)", after[2][1], wantSize)
+	}
+}

--- a/disk/disk_openexclusive_linux_test.go
+++ b/disk/disk_openexclusive_linux_test.go
@@ -1,0 +1,137 @@
+//go:build linux
+
+package disk_test
+
+// On-device regression test for the non-exclusive whole-disk open added as
+// file.OpenFromPathWithExclusive. resize2fs/e2fsck open their target partition
+// O_EXCL; if a consumer holds the *parent* whole disk open with O_EXCL (what
+// file.OpenFromPath does by default), the kernel refuses that child-partition
+// O_EXCL open with EBUSY ("device is in use"). Opening the disk non-exclusively
+// (exclusive=false) lets the child open succeed, so the filesystem tools can
+// run on a partition while go-diskfs still holds the disk for the GPT rewrite.
+//
+// The file-based tests cannot reach this: O_EXCL is a no-op on a regular file
+// and a file has no child partition nodes, so the conflict only appears on a
+// real block device. The two subtests prove both directions in one run -- the
+// exclusive open reproduces the bug, the non-exclusive open is the fix. It
+// requires root (losetup) and is skipped otherwise.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	diskfs "github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+)
+
+func TestOpenExclusiveBlocksChildPartitionFsck(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for losetup")
+	}
+	requireCmd(t, "losetup")
+
+	tmp := t.TempDir()
+	imgPath := filepath.Join(tmp, "disk.img")
+
+	// 64 MiB image with a single 8 MiB partition; the partition is the fsck
+	// target, the whole disk is what go-diskfs holds open.
+	const (
+		diskSize     = int64(64 << 20)
+		p1Start      = uint64(2048)
+		eightMiBSecs = uint64(8 << 20 / sectorBytes)
+	)
+	f, err := os.Create(imgPath)
+	if err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+	if err := f.Truncate(diskSize); err != nil {
+		t.Fatalf("truncate image: %v", err)
+	}
+	f.Close()
+
+	// Lay down the GPT on the file (regular file: no exclusive-open conflict).
+	bk, err := file.OpenFromPathWithExclusive(imgPath, false, false)
+	if err != nil {
+		t.Fatalf("open image: %v", err)
+	}
+	d, err := diskfs.OpenBackend(bk, diskfs.WithSectorSize(diskfs.SectorSize512))
+	if err != nil {
+		t.Fatalf("OpenBackend image: %v", err)
+	}
+	table := &gpt.Table{
+		LogicalSectorSize:  sectorBytes,
+		PhysicalSectorSize: sectorBytes,
+		ProtectiveMBR:      true,
+		Partitions: []*gpt.Partition{
+			mkPartition(1, "child", p1Start, eightMiBSecs),
+		},
+	}
+	if err := d.Partition(table); err != nil {
+		t.Fatalf("write table: %v", err)
+	}
+	if err := bk.Close(); err != nil {
+		t.Fatalf("close image: %v", err)
+	}
+
+	// Expose as a loop device with partition scanning so the child node appears.
+	loopdev := run(t, "losetup", "--find", "--partscan", "--show", imgPath)
+	t.Cleanup(func() { _ = exec.Command("losetup", "--detach", loopdev).Run() })
+	if _, err := exec.LookPath("udevadm"); err == nil {
+		_ = exec.Command("udevadm", "settle").Run()
+	}
+
+	childDev := loopdev + "p1"
+	if _, err := os.Stat(childDev); err != nil {
+		t.Fatalf("child partition node %s did not appear: %v", childDev, err)
+	}
+
+	// openChildExclusive mimics e2fsck/resize2fs, which open their target
+	// O_EXCL. Returns the open error (nil = the tool could run).
+	openChildExclusive := func() error {
+		cf, err := os.OpenFile(childDev, os.O_RDWR|os.O_EXCL, 0)
+		if err != nil {
+			return err
+		}
+		return cf.Close()
+	}
+
+	// Precondition: with nothing holding the parent, the child opens
+	// exclusively. If even this fails, the environment cannot host the test
+	// (e.g. an auto-mounter grabbed the partition) -- skip rather than fail.
+	if err := openChildExclusive(); err != nil {
+		t.Skipf("child O_EXCL open fails with no parent holder (%v); environment cannot host this test", err)
+	}
+
+	// The bug: holding the parent disk O_EXCL (the OpenFromPath default) makes
+	// the kernel refuse the child's O_EXCL open.
+	t.Run("ParentExclusiveBlocksChild", func(t *testing.T) {
+		parent, err := file.OpenFromPathWithExclusive(loopdev, false, true)
+		if err != nil {
+			t.Fatalf("open parent O_EXCL: %v", err)
+		}
+		defer func() { _ = parent.Close() }()
+
+		if err := openChildExclusive(); err == nil {
+			t.Fatal("child O_EXCL open succeeded while parent held O_EXCL; the exclusive open did not claim the disk")
+		} else {
+			t.Logf("child O_EXCL open blocked as expected: %v", err)
+		}
+	})
+
+	// The fix: holding the parent non-exclusively leaves the child openable, so
+	// resize2fs/e2fsck can run on it.
+	t.Run("ParentNonExclusiveAllowsChild", func(t *testing.T) {
+		parent, err := file.OpenFromPathWithExclusive(loopdev, false, false)
+		if err != nil {
+			t.Fatalf("open parent non-exclusive: %v", err)
+		}
+		defer func() { _ = parent.Close() }()
+
+		if err := openChildExclusive(); err != nil {
+			t.Fatalf("child O_EXCL open failed while parent held non-exclusively: %v; resize2fs/e2fsck would be blocked", err)
+		}
+	})
+}

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -4,6 +4,7 @@
 package disk
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -46,6 +47,15 @@ func (d *Disk) ReReadPartitionTable() error {
 
 	if _, rrErr := unix.IoctlGetInt(fd, blkrrpart); rrErr != nil {
 		if pgErr := d.reconcilePartitionsBLKPG(fd); pgErr != nil {
+			// The table is already written to disk (Partition() does that before
+			// calling us). A BLKRRPART EBUSY means a partition is mounted/held —
+			// i.e. we are repartitioning the disk we booted from — and the BLKPG
+			// per-partition fallback can't tear down the in-use partition either.
+			// Signal reboot-to-apply rather than a hard failure: the next boot's
+			// partition scan reads the committed on-disk table cleanly.
+			if errors.Is(rrErr, unix.EBUSY) {
+				return fmt.Errorf("%w (BLKRRPART: %v; BLKPG: %v)", ErrReReadDeferred, rrErr, pgErr)
+			}
 			return fmt.Errorf("unable to re-read the partition table. Kernel still uses old partition table (BLKRRPART: %v; BLKPG: %v)", rrErr, pgErr)
 		}
 	}

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -10,14 +10,23 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	blkrrpart = 0x125f
-)
+// blkrrpart is the Linux BLKRRPART ioctl (uapi/linux/fs.h). The call compiles
+// on every unix via unix.IoctlGetInt and simply fails at runtime on platforms
+// that do not implement it.
+const blkrrpart = 0x125f
 
-// ReReadPartitionTable forces the kernel to re-read the partition table
-// on the disk.
+// ReReadPartitionTable makes the kernel pick up the on-disk partition table.
 //
-// It is done via an ioctl call with request as BLKRRPART.
+// It first tries a whole-disk re-read via the BLKRRPART ioctl. That is
+// all-or-nothing and fails with EBUSY whenever the kernel or udev is
+// transiently holding any partition -- which is common immediately after a
+// partition-table write, because the write triggers a udev re-probe -- or when
+// a partition is mounted. When BLKRRPART fails, it falls back to per-partition
+// BLKPG reconciliation (the same mechanism partx/parted use): it adds, removes,
+// and re-creates only the entries whose geometry changed, via BLKPG ioctls that
+// do not require a whole-disk exclusive re-read. This keeps the library free of
+// any dependency on external tools such as partx. The fallback is Linux-only;
+// on other platforms it reports that the re-read could not be completed.
 func (d *Disk) ReReadPartitionTable() error {
 	// the partition table needs to be re-read only if
 	// the disk file is an actual block device
@@ -25,16 +34,19 @@ func (d *Disk) ReReadPartitionTable() error {
 	if err != nil {
 		return err
 	}
+	if devInfo.Mode()&os.ModeDevice == 0 {
+		return nil
+	}
 
-	if devInfo.Mode()&os.ModeDevice != 0 {
-		osFile, err := d.Backend.Sys()
-		if err != nil {
-			return err
-		}
-		fd := osFile.Fd()
-		_, err = unix.IoctlGetInt(int(fd), blkrrpart)
-		if err != nil {
-			return fmt.Errorf("unable to re-read the partition table. Kernel still uses old partition table: %v", err)
+	osFile, err := d.Backend.Sys()
+	if err != nil {
+		return err
+	}
+	fd := int(osFile.Fd())
+
+	if _, rrErr := unix.IoctlGetInt(fd, blkrrpart); rrErr != nil {
+		if pgErr := d.reconcilePartitionsBLKPG(fd); pgErr != nil {
+			return fmt.Errorf("unable to re-read the partition table. Kernel still uses old partition table (BLKRRPART: %v; BLKPG: %v)", rrErr, pgErr)
 		}
 	}
 


### PR DESCRIPTION
Two fixes needed to run partition tools (`e2fsck`/`resize2fs`) against the
partitions of a live block device. The file-based tests cannot reach either
path, so both were surfaced running a downstream resizer against a real
`/dev/nbd0`.

- **`file.OpenFromPathWithExclusive`** lets a caller open a device read-write
  *without* `O_EXCL` while still recording the path (`OpenFromPath` keeps its
  `O_EXCL` default). Holding the whole disk `O_EXCL` makes the kernel reject
  `O_EXCL` opens of its child partitions ("device is in use"), so a tool that
  shells out to `e2fsck`/`resize2fs` cannot hold the disk exclusively.

- **`ReReadPartitionTable`** falls back to per-partition **BLKPG**
  reconciliation when `BLKRRPART` fails — EBUSY during the udev re-probe a
  table write triggers, or a mounted sibling partition. BLKPG adds/removes/
  recreates only the changed entries via ioctls, with no whole-disk exclusive
  re-read and no dependency on external tools (`partx`).

On a regular file `O_EXCL` is a no-op and there are no partition nodes to
re-read, which is why the existing file-based tests never exercise either
path. Two root-gated loop-device tests cover the fixes:

- `disk/disk_blockdev_linux_test.go` exercises the BLKPG fallback: it mounts
  one partition to force `BLKRRPART` EBUSY, shrinks another, and verifies the
  kernel picks up the change while the mounted sibling is left untouched.

- `disk/disk_openexclusive_linux_test.go` exercises the non-exclusive open: a
  parent held `O_EXCL` blocks an `O_EXCL` open of its child partition (the
  `e2fsck`/`resize2fs` case) with EBUSY, while a non-exclusive parent leaves
  the child openable.
