### PR TITLE
ext4: fix extent tree splits for large fragmented files

### DIFF
--- a/filesystem/ext4/extent.go
+++ b/filesystem/ext4/extent.go
@@ -440,7 +440,7 @@ func extendLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent
 			if err != nil {
 				return nil, 0, err
 			}
-			newRoot := createInternalNode([]extentBlockFinder{newLeaf}, nil, fs)
+			newRoot := createInternalNode([]extentBlockFinder{newLeaf})
 			return newRoot, metaBlocks, nil
 		}
 
@@ -455,7 +455,7 @@ func extendLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent
 		for _, n := range newNodes {
 			newNodesAsBlockFinder = append(newNodesAsBlockFinder, n)
 		}
-		newRoot := createInternalNode(newNodesAsBlockFinder, nil, fs)
+		newRoot := createInternalNode(newNodesAsBlockFinder)
 		return newRoot, metaBlocks, nil
 	}
 
@@ -625,46 +625,25 @@ func promoteLeafToChild(node *extentLeafNode, added *extents, fs *FileSystem) (*
 	return newLeaf, 1, nil
 }
 
-func createInternalNode(nodes []extentBlockFinder, parent *extentInternalNode, fs *FileSystem) *extentInternalNode {
-	// Calculate max entries for internal nodes (based on block size)
-	// Each entry is 12 bytes, header is 12 bytes
-	// For root node in inode, max is 4
-	maxEntries := uint16(4)
-	if parent != nil {
-		maxEntries = uint16((nodes[0].getBlockSize() - 12) / 12)
-	}
-
+func createInternalNode(nodes []extentBlockFinder) *extentInternalNode {
+	// Always builds a new root internal node, which lives in the inode: capped at
+	// 4 entries and persisted with the inode, so nothing is written to disk here.
 	internalNode := &extentInternalNode{
 		extentNodeHeader: extentNodeHeader{
 			depth:     nodes[0].getDepth() + 1, // Depth is 1 more than the children
 			entries:   uint16(len(nodes)),
-			max:       maxEntries,
+			max:       4,
 			blockSize: nodes[0].getBlockSize(),
 		},
 		children: make([]*extentChildPtr, len(nodes)),
 	}
-
 	for i, node := range nodes {
-		var diskBlock uint64
-		if parent == nil {
-			// When creating a new root, get disk block from the node itself
-			diskBlock = getDiskBlockFromNode(node)
-		} else {
-			diskBlock = getBlockNumberFromNode(node, parent)
-		}
 		internalNode.children[i] = &extentChildPtr{
 			fileBlock: node.getFileBlock(),
 			count:     node.getCount(),
-			diskBlock: diskBlock,
+			diskBlock: getDiskBlockFromNode(node),
 		}
 	}
-
-	// Write the new internal node to the disk (root nodes live in inode, so parent==nil means no write)
-	err := writeNodeToDisk(internalNode, fs, parent)
-	if err != nil {
-		return nil
-	}
-
 	return internalNode
 }
 
@@ -755,7 +734,7 @@ func extendInternalNode(node *extentInternalNode, added *extents, fs *FileSystem
 				for _, n := range newInternalNodes {
 					newNodesAsBlockFinder = append(newNodesAsBlockFinder, n)
 				}
-				newRoot := createInternalNode(newNodesAsBlockFinder, nil, fs)
+				newRoot := createInternalNode(newNodesAsBlockFinder)
 				return newRoot, metaBlocks, nil
 			}
 			return nil, 0, fmt.Errorf("internal node split with non-root parent not supported")
@@ -784,7 +763,7 @@ func extendInternalNode(node *extentInternalNode, added *extents, fs *FileSystem
 	// Check if the internal node is at capacity
 	if len(node.children) > int(node.max) {
 		// Split the internal node if it's at capacity
-		newInternalNodes, err := splitInternalNode(node, node.children[childIndex], fs, parent)
+		newInternalNodes, err := splitInternalNode(node, node.children[childIndex], fs)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -796,7 +775,7 @@ func extendInternalNode(node *extentInternalNode, added *extents, fs *FileSystem
 			for _, n := range newInternalNodes {
 				newNodesAsBlockFinder = append(newNodesAsBlockFinder, n)
 			}
-			newRoot := createInternalNode(newNodesAsBlockFinder, nil, fs)
+			newRoot := createInternalNode(newNodesAsBlockFinder)
 			return newRoot, metaBlocks, nil
 		}
 
@@ -868,7 +847,7 @@ func splitInternalNodeChildren(node *extentInternalNode, fs *FileSystem) ([]*ext
 	return []*extentInternalNode{firstInternal, secondInternal}, 2, nil
 }
 
-func splitInternalNode(node *extentInternalNode, newChild *extentChildPtr, fs *FileSystem, parent *extentInternalNode) ([]*extentInternalNode, error) {
+func splitInternalNode(node *extentInternalNode, newChild *extentChildPtr, fs *FileSystem) ([]*extentInternalNode, error) {
 	// Combine existing children with the new child
 	allChildren := node.children
 	allChildren = append(allChildren, newChild)

--- a/filesystem/ext4/extent.go
+++ b/filesystem/ext4/extent.go
@@ -445,7 +445,7 @@ func extendLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent
 		}
 
 		// Otherwise split the node
-		newNodes, metaBlocks, err := splitLeafNode(node, added, fs, parent)
+		newNodes, metaBlocks, err := splitLeafNode(node, added, fs)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -460,7 +460,7 @@ func extendLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent
 	}
 
 	// If not enough space in a non-root node, split it
-	newNodes, splitMetaBlocks, err := splitLeafNode(node, added, fs, parent)
+	newNodes, splitMetaBlocks, err := splitLeafNode(node, added, fs)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -508,7 +508,7 @@ func extendLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent
 	return parent, splitMetaBlocks, nil
 }
 
-func splitLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent *extentInternalNode) ([]*extentLeafNode, uint64, error) {
+func splitLeafNode(node *extentLeafNode, added *extents, fs *FileSystem) ([]*extentLeafNode, uint64, error) {
 	// Combine existing and new extents
 	allExtents := node.extents
 	allExtents = append(allExtents, *added...)
@@ -546,55 +546,27 @@ func splitLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent 
 		extents: allExtents[mid:],
 	}
 
-	var metaBlocks uint64
+	// Allocate disk blocks for the new leaf nodes explicitly. writeNodeToDisk cannot
+	// be used here because freshly split nodes are not yet registered in any parent's
+	// children list (the caller updates the parent after this function returns), so
+	// the parent-lookup path cannot resolve their block numbers.
+	blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not allocate blocks for split leaf nodes: %w", err)
+	}
+	allocatedExtents := *blockAlloc
+	if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
+		return nil, 0, fmt.Errorf("could not allocate enough blocks for split leaf nodes")
+	}
+	firstLeaf.diskBlock = allocatedExtents[0].startingBlock
+	secondLeaf.diskBlock = allocatedExtents[0].startingBlock + 1
+	metaBlocks := uint64(2)
 
-	// When splitting the root (parent == nil), we need to allocate new disk blocks
-	// for the child nodes since they will no longer live in the inode
-	if parent == nil {
-		// Allocate blocks for both new leaf nodes
-		blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
-		if err != nil {
-			return nil, 0, fmt.Errorf("could not allocate blocks for split leaf nodes: %w", err)
-		}
-		// Get the starting block from the allocated extent
-		allocatedExtents := *blockAlloc
-		if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
-			return nil, 0, fmt.Errorf("could not allocate enough blocks for split leaf nodes")
-		}
-		firstLeaf.diskBlock = allocatedExtents[0].startingBlock
-		secondLeaf.diskBlock = allocatedExtents[0].startingBlock + 1
-		metaBlocks = 2
-
-		// Write the leaf nodes to their allocated blocks
-		if err := writeNodeToBlock(firstLeaf, fs, firstLeaf.diskBlock); err != nil {
-			return nil, 0, err
-		}
-		if err := writeNodeToBlock(secondLeaf, fs, secondLeaf.diskBlock); err != nil {
-			return nil, 0, err
-		}
-	} else {
-		// Non-root split: allocate disk blocks for the new leaf nodes.
-		// The parent-lookup path (writeNodeToDisk) cannot find freshly
-		// created nodes that aren't yet registered in parent.children,
-		// so we allocate explicitly and use writeNodeToBlock instead.
-		blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
-		if err != nil {
-			return nil, 0, fmt.Errorf("could not allocate blocks for split leaf nodes: %w", err)
-		}
-		allocatedExtents := *blockAlloc
-		if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
-			return nil, 0, fmt.Errorf("could not allocate enough blocks for split leaf nodes")
-		}
-		firstLeaf.diskBlock = allocatedExtents[0].startingBlock
-		secondLeaf.diskBlock = allocatedExtents[0].startingBlock + 1
-		metaBlocks = 2
-
-		if err := writeNodeToBlock(firstLeaf, fs, firstLeaf.diskBlock); err != nil {
-			return nil, 0, err
-		}
-		if err := writeNodeToBlock(secondLeaf, fs, secondLeaf.diskBlock); err != nil {
-			return nil, 0, err
-		}
+	if err := writeNodeToBlock(firstLeaf, fs, firstLeaf.diskBlock); err != nil {
+		return nil, 0, err
+	}
+	if err := writeNodeToBlock(secondLeaf, fs, secondLeaf.diskBlock); err != nil {
+		return nil, 0, err
 	}
 
 	return []*extentLeafNode{firstLeaf, secondLeaf}, metaBlocks, nil

--- a/filesystem/ext4/extent.go
+++ b/filesystem/ext4/extent.go
@@ -573,13 +573,26 @@ func splitLeafNode(node *extentLeafNode, added *extents, fs *FileSystem, parent 
 			return nil, 0, err
 		}
 	} else {
-		// Write new leaf nodes to the disk using parent reference
-		err := writeNodeToDisk(firstLeaf, fs, parent)
+		// Non-root split: allocate disk blocks for the new leaf nodes.
+		// The parent-lookup path (writeNodeToDisk) cannot find freshly
+		// created nodes that aren't yet registered in parent.children,
+		// so we allocate explicitly and use writeNodeToBlock instead.
+		blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
 		if err != nil {
+			return nil, 0, fmt.Errorf("could not allocate blocks for split leaf nodes: %w", err)
+		}
+		allocatedExtents := *blockAlloc
+		if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
+			return nil, 0, fmt.Errorf("could not allocate enough blocks for split leaf nodes")
+		}
+		firstLeaf.diskBlock = allocatedExtents[0].startingBlock
+		secondLeaf.diskBlock = allocatedExtents[0].startingBlock + 1
+		metaBlocks = 2
+
+		if err := writeNodeToBlock(firstLeaf, fs, firstLeaf.diskBlock); err != nil {
 			return nil, 0, err
 		}
-		err = writeNodeToDisk(secondLeaf, fs, parent)
-		if err != nil {
+		if err := writeNodeToBlock(secondLeaf, fs, secondLeaf.diskBlock); err != nil {
 			return nil, 0, err
 		}
 	}
@@ -745,6 +758,30 @@ func extendInternalNode(node *extentInternalNode, added *extents, fs *FileSystem
 		return nil, 0, err
 	}
 
+	// When a non-root leaf split occurs, extendLeafNode directly updates
+	// our children and returns us (node) back. Detect this and skip the
+	// redundant child-pointer update — but still split if the inode-root
+	// internal node exceeded its max (4 entries).
+	if asInternal, ok := updatedChild.(*extentInternalNode); ok && asInternal == node {
+		if len(node.children) > int(node.max) {
+			newInternalNodes, splitMeta, err := splitInternalNodeChildren(node, fs)
+			if err != nil {
+				return nil, 0, err
+			}
+			metaBlocks += splitMeta
+			if parent == nil {
+				var newNodesAsBlockFinder []extentBlockFinder
+				for _, n := range newInternalNodes {
+					newNodesAsBlockFinder = append(newNodesAsBlockFinder, n)
+				}
+				newRoot := createInternalNode(newNodesAsBlockFinder, nil, fs)
+				return newRoot, metaBlocks, nil
+			}
+			return nil, 0, fmt.Errorf("internal node split with non-root parent not supported")
+		}
+		return node, metaBlocks, nil
+	}
+
 	// Update the current internal node to reference the updated child
 	switch updatedChild := updatedChild.(type) {
 	case *extentLeafNode:
@@ -795,6 +832,61 @@ func extendInternalNode(node *extentInternalNode, added *extents, fs *FileSystem
 	return node, metaBlocks, nil
 }
 
+// nonRootInternalMaxEntries is the max child pointers for an internal node
+// stored on disk (not in the inode root, which is capped at 4).
+func nonRootInternalMaxEntries(blockSize uint32) uint16 {
+	return uint16((blockSize - 12) / 12)
+}
+
+// splitInternalNodeChildren splits an over-capacity internal node into two
+// on-disk internal nodes. Used when a leaf split under the inode-root
+// internal node pushes child count past max (4).
+func splitInternalNodeChildren(node *extentInternalNode, fs *FileSystem) ([]*extentInternalNode, uint64, error) {
+	allChildren := node.children
+	mid := len(allChildren) / 2
+	maxEntries := nonRootInternalMaxEntries(node.blockSize)
+
+	firstInternal := &extentInternalNode{
+		extentNodeHeader: extentNodeHeader{
+			depth:     node.depth,
+			entries:   uint16(mid),
+			max:       maxEntries,
+			blockSize: node.blockSize,
+		},
+		children: allChildren[:mid],
+	}
+
+	secondInternal := &extentInternalNode{
+		extentNodeHeader: extentNodeHeader{
+			depth:     node.depth,
+			entries:   uint16(len(allChildren) - mid),
+			max:       maxEntries,
+			blockSize: node.blockSize,
+		},
+		children: allChildren[mid:],
+	}
+
+	blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not allocate blocks for split internal nodes: %w", err)
+	}
+	allocatedExtents := *blockAlloc
+	if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
+		return nil, 0, fmt.Errorf("could not allocate enough blocks for split internal nodes")
+	}
+	firstInternal.diskBlock = allocatedExtents[0].startingBlock
+	secondInternal.diskBlock = allocatedExtents[0].startingBlock + 1
+
+	if err := writeNodeToBlock(firstInternal, fs, firstInternal.diskBlock); err != nil {
+		return nil, 0, err
+	}
+	if err := writeNodeToBlock(secondInternal, fs, secondInternal.diskBlock); err != nil {
+		return nil, 0, err
+	}
+
+	return []*extentInternalNode{firstInternal, secondInternal}, 2, nil
+}
+
 func splitInternalNode(node *extentInternalNode, newChild *extentChildPtr, fs *FileSystem, parent *extentInternalNode) ([]*extentInternalNode, error) {
 	// Combine existing children with the new child
 	allChildren := node.children
@@ -806,13 +898,14 @@ func splitInternalNode(node *extentInternalNode, newChild *extentChildPtr, fs *F
 
 	// Calculate the midpoint to split the children
 	mid := len(allChildren) / 2
+	maxEntries := nonRootInternalMaxEntries(node.blockSize)
 
 	// Create the first new internal node
 	firstInternal := &extentInternalNode{
 		extentNodeHeader: extentNodeHeader{
 			depth:     node.depth,
 			entries:   uint16(mid),
-			max:       node.max,
+			max:       maxEntries,
 			blockSize: node.blockSize,
 		},
 		children: allChildren[:mid],
@@ -823,19 +916,30 @@ func splitInternalNode(node *extentInternalNode, newChild *extentChildPtr, fs *F
 		extentNodeHeader: extentNodeHeader{
 			depth:     node.depth,
 			entries:   uint16(len(allChildren) - mid),
-			max:       node.max,
+			max:       maxEntries,
 			blockSize: node.blockSize,
 		},
 		children: allChildren[mid:],
 	}
 
-	// Write new internal nodes to the disk
-	err := writeNodeToDisk(firstInternal, fs, parent)
+	// Allocate blocks for both new internal nodes. Same issue as
+	// splitLeafNode: freshly created nodes aren't in parent.children yet,
+	// so writeNodeToDisk's lookup would fail.
+	blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
 	if err != nil {
+		return nil, fmt.Errorf("could not allocate blocks for split internal nodes: %w", err)
+	}
+	allocatedExtents := *blockAlloc
+	if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
+		return nil, fmt.Errorf("could not allocate enough blocks for split internal nodes")
+	}
+	firstInternal.diskBlock = allocatedExtents[0].startingBlock
+	secondInternal.diskBlock = allocatedExtents[0].startingBlock + 1
+
+	if err := writeNodeToBlock(firstInternal, fs, firstInternal.diskBlock); err != nil {
 		return nil, err
 	}
-	err = writeNodeToDisk(secondInternal, fs, parent)
-	if err != nil {
+	if err := writeNodeToBlock(secondInternal, fs, secondInternal.diskBlock); err != nil {
 		return nil, err
 	}
 

--- a/filesystem/ext4/extent.go
+++ b/filesystem/ext4/extent.go
@@ -546,21 +546,30 @@ func splitLeafNode(node *extentLeafNode, added *extents, fs *FileSystem) ([]*ext
 		extents: allExtents[mid:],
 	}
 
-	// Allocate disk blocks for the new leaf nodes explicitly. writeNodeToDisk cannot
-	// be used here because freshly split nodes are not yet registered in any parent's
-	// children list (the caller updates the parent after this function returns), so
-	// the parent-lookup path cannot resolve their block numbers.
-	blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*2, nil)
+	// A non-root leaf already lives on disk (node.diskBlock != 0): reuse that
+	// block for one half and allocate a single new block for the other, matching
+	// ext4 ([A] -> [A, C]) and avoiding a leak. The inode-root leaf
+	// (node.diskBlock == 0) has no block to reuse, so allocate two.
+	newBlocks := 1
+	if node.diskBlock == 0 {
+		newBlocks = 2
+	}
+	blockAlloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize)*uint64(newBlocks), nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("could not allocate blocks for split leaf nodes: %w", err)
 	}
 	allocatedExtents := *blockAlloc
-	if len(allocatedExtents) == 0 || allocatedExtents[0].count < 2 {
+	if len(allocatedExtents) == 0 || int(allocatedExtents[0].count) < newBlocks {
 		return nil, 0, fmt.Errorf("could not allocate enough blocks for split leaf nodes")
 	}
-	firstLeaf.diskBlock = allocatedExtents[0].startingBlock
-	secondLeaf.diskBlock = allocatedExtents[0].startingBlock + 1
-	metaBlocks := uint64(2)
+	if node.diskBlock != 0 {
+		firstLeaf.diskBlock = node.diskBlock
+		secondLeaf.diskBlock = allocatedExtents[0].startingBlock
+	} else {
+		firstLeaf.diskBlock = allocatedExtents[0].startingBlock
+		secondLeaf.diskBlock = allocatedExtents[0].startingBlock + 1
+	}
+	metaBlocks := uint64(newBlocks)
 
 	if err := writeNodeToBlock(firstLeaf, fs, firstLeaf.diskBlock); err != nil {
 		return nil, 0, err

--- a/filesystem/ext4/extent_test.go
+++ b/filesystem/ext4/extent_test.go
@@ -747,7 +747,7 @@ func TestChildPtrMatchesNode(t *testing.T) {
 // image and returns it along with the image path (for e2fsck).
 // Sizes >= 512 MiB get auto-detected 4 KiB blocks, which is what the
 // split paths in extent.go are sized for.
-func setupWritableExtentFS(t *testing.T, size int64) (*FileSystem, string) {
+func setupWritableExtentFS(t *testing.T, size int64) (fs *FileSystem, imagePath string) {
 	t.Helper()
 	outfile, f := testCreateEmptyFile(t, size)
 	t.Cleanup(func() { _ = f.Close() })

--- a/filesystem/ext4/extent_test.go
+++ b/filesystem/ext4/extent_test.go
@@ -1,8 +1,15 @@
 package ext4
 
 import (
+	"bytes"
+	"crypto/rand"
 	"encoding/binary"
+	"io"
+	"os"
+	"os/exec"
 	"testing"
+
+	"github.com/diskfs/go-diskfs/backend/file"
 )
 
 // TestExtentNodeHeaderToBytes tests serialization of the extent node header
@@ -543,12 +550,10 @@ func TestGetDiskBlockFromNode(t *testing.T) {
 	}
 }
 
-// TestCreateRootExtentTree tests creation of a new root extent tree
+// TestCreateRootExtentTree tests creation of a new root extent tree.
+// Full extendExtentTree coverage lives in TestExtendExtentTreeSplitRegression,
+// which exercises the on-disk split paths.
 func TestCreateRootExtentTree(t *testing.T) {
-	// We can't test extendExtentTree directly without a full filesystem,
-	// but we can test createRootExtentTree which doesn't need disk I/O
-	// if the extents fit in 4 entries.
-
 	t.Run("fits in root", func(t *testing.T) {
 		exts := &extents{
 			{fileBlock: 0, startingBlock: 100, count: 5},
@@ -735,5 +740,222 @@ func TestChildPtrMatchesNode(t *testing.T) {
 	}
 	if childPtrMatchesNode(nonMatchingPtr, leaf) {
 		t.Errorf("expected non-matching ptr to not match leaf node")
+	}
+}
+
+// setupWritableExtentFS creates a fresh ext4 filesystem on a sparse temp
+// image and returns it along with the image path (for e2fsck).
+// Sizes >= 512 MiB get auto-detected 4 KiB blocks, which is what the
+// split paths in extent.go are sized for.
+func setupWritableExtentFS(t *testing.T, size int64) (*FileSystem, string) {
+	t.Helper()
+	outfile, f := testCreateEmptyFile(t, size)
+	t.Cleanup(func() { _ = f.Close() })
+	fs, err := Create(file.New(f, false), size, 0, 512, &Params{})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	return fs, outfile
+}
+
+// extendTreeWithBlock allocates a single filesystem block and grafts it
+// onto tree as a new one-block extent at the given fileBlock offset.
+// This drives extendExtentTree through every split path without the
+// overhead of an actual File.Write.
+func extendTreeWithBlock(t *testing.T, fs *FileSystem, tree extentBlockFinder, fileBlock uint32) extentBlockFinder {
+	t.Helper()
+	alloc, err := fs.allocateExtents(uint64(fs.superblock.blockSize), nil)
+	if err != nil {
+		t.Fatalf("allocateExtents at fileBlock %d failed: %v", fileBlock, err)
+	}
+	if alloc == nil || len(*alloc) == 0 {
+		t.Fatalf("allocateExtents returned no extents at fileBlock %d", fileBlock)
+	}
+	added := extents{{
+		fileBlock:     fileBlock,
+		startingBlock: (*alloc)[0].startingBlock,
+		count:         1,
+	}}
+	updated, _, err := extendExtentTree(tree, &added, fs, nil)
+	if err != nil {
+		t.Fatalf("extendExtentTree at fileBlock %d failed: %v", fileBlock, err)
+	}
+	return updated
+}
+
+// walkAndLoadChildren recurses through an extent tree, loading each
+// internal child from disk via loadChildNode. This confirms that every
+// node returned by a split was actually allocated a real disk block and
+// the bytes there round-trip back through parseExtents.
+func walkAndLoadChildren(t *testing.T, fs *FileSystem, node extentBlockFinder) {
+	t.Helper()
+	internal, ok := node.(*extentInternalNode)
+	if !ok {
+		return
+	}
+	for _, child := range internal.children {
+		if child.diskBlock == 0 {
+			t.Errorf("child at fileBlock %d has zero diskBlock", child.fileBlock)
+			continue
+		}
+		loaded, err := loadChildNode(child, fs)
+		if err != nil {
+			t.Fatalf("loadChildNode at diskBlock %d: %v", child.diskBlock, err)
+		}
+		walkAndLoadChildren(t, fs, loaded)
+	}
+}
+
+// TestExtendExtentTreeSplitRegression exercises the split paths in
+// extent.go that previously failed for large files. With 4 KiB blocks
+// each non-root leaf holds up to (4096-12)/12 = 340 extents and the
+// inode-root internal node is capped at 4 children.
+func TestExtendExtentTreeSplitRegression(t *testing.T) {
+	// 350 single-block extents force one non-root leaf split (at the
+	// 341st add). Pre-fix this failed with
+	// "block number not found for node" because splitLeafNode did not
+	// allocate disk blocks for the new leaves.
+	t.Run("nonRootLeafSplit", func(t *testing.T) {
+		fs, _ := setupWritableExtentFS(t, 600*MB)
+		var tree extentBlockFinder
+		const n = 350
+		for i := uint32(0); i < n; i++ {
+			tree = extendTreeWithBlock(t, fs, tree, i)
+		}
+		if tree == nil {
+			t.Fatalf("expected non-nil tree after %d extends", n)
+		}
+		if got := tree.getDepth(); got < 1 {
+			t.Fatalf("expected tree depth >= 1 after split, got %d", got)
+		}
+		all, err := tree.blocks(fs)
+		if err != nil {
+			t.Fatalf("tree.blocks failed: %v", err)
+		}
+		if len(all) != n {
+			t.Fatalf("expected %d extents in tree, got %d", n, len(all))
+		}
+		for i, ext := range all {
+			if ext.fileBlock != uint32(i) {
+				t.Fatalf("extent[%d].fileBlock = %d, want %d", i, ext.fileBlock, i)
+			}
+			if ext.count != 1 {
+				t.Fatalf("extent[%d].count = %d, want 1", i, ext.count)
+			}
+		}
+		walkAndLoadChildren(t, fs, tree)
+	})
+
+	// 900 single-block extents trigger four leaf splits, pushing the
+	// inode-root internal node to 5 children (max is 4). Pre-fix this
+	// panicked while serializing the over-capacity root; the fix adds
+	// splitInternalNodeChildren and produces a depth-2 root.
+	t.Run("inodeRootInternalOverflow", func(t *testing.T) {
+		fs, _ := setupWritableExtentFS(t, 600*MB)
+		var tree extentBlockFinder
+		const n = 900
+		for i := uint32(0); i < n; i++ {
+			tree = extendTreeWithBlock(t, fs, tree, i)
+		}
+		root, ok := tree.(*extentInternalNode)
+		if !ok {
+			t.Fatalf("expected root *extentInternalNode after %d extends, got %T", n, tree)
+		}
+		if len(root.children) > int(root.max) {
+			t.Fatalf("inode root over capacity: %d children, max %d", len(root.children), root.max)
+		}
+		if root.depth != 2 {
+			t.Fatalf("expected root depth 2 after inode-root split, got %d", root.depth)
+		}
+		// Pre-fix this slice index past max would panic; assert it now succeeds.
+		_ = root.toBytes()
+
+		all, err := tree.blocks(fs)
+		if err != nil {
+			t.Fatalf("tree.blocks failed: %v", err)
+		}
+		if len(all) != n {
+			t.Fatalf("expected %d extents in tree, got %d", n, len(all))
+		}
+		walkAndLoadChildren(t, fs, tree)
+	})
+}
+
+// TestExtendExtentTreeLargeFile reproduces the original OCI flatten
+// failure: writing a large binary in small chunks fragments allocations
+// across hundreds of extents and forces the extent tree to grow through
+// every split path. Pre-fix this returned
+// "could not convert extents into tree: block number not found for node".
+func TestExtendExtentTreeLargeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large file regression in short mode")
+	}
+	const (
+		fsSize    = 500 * MB
+		fileSize  = 80 * 1024 * 1024
+		chunkSize = 32 * 1024
+	)
+	outfile, f := testCreateEmptyFile(t, fsSize)
+	defer f.Close()
+
+	fs, err := Create(file.New(f, false), fsSize, 0, 512, &Params{})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	data := make([]byte, fileSize)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand.Read failed: %v", err)
+	}
+
+	ext4File, err := fs.OpenFile("/node.bin", os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		t.Fatalf("OpenFile failed: %v", err)
+	}
+	for offset := 0; offset < fileSize; offset += chunkSize {
+		end := offset + chunkSize
+		if end > fileSize {
+			end = fileSize
+		}
+		nWritten, err := ext4File.Write(data[offset:end])
+		if err != nil {
+			t.Fatalf("Write at offset %d failed: %v", offset, err)
+		}
+		if nWritten != end-offset {
+			t.Fatalf("short write at offset %d: got %d want %d", offset, nWritten, end-offset)
+		}
+	}
+
+	if _, err := ext4File.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek failed: %v", err)
+	}
+	readBuf := make([]byte, fileSize)
+	total := 0
+	for total < fileSize {
+		nRead, err := ext4File.Read(readBuf[total:])
+		if nRead > 0 {
+			total += nRead
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Read at offset %d failed: %v", total, err)
+		}
+	}
+	if total != fileSize {
+		t.Fatalf("read %d bytes, want %d", total, fileSize)
+	}
+	if !bytes.Equal(data, readBuf) {
+		t.Errorf("payload mismatch after large file round trip")
+	}
+
+	if err := f.Sync(); err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	cmd := exec.Command("e2fsck", "-f", "-n", outfile)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("e2fsck failed: %v\n%s", err, string(out))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes bugs in ext4 extent tree growth when leaf or internal nodes split during `extendExtentTree`. These failures showed up when writing large, fragmented files whose extent trees grow beyond the inode-root limits, for example, copying large binaries from container images such as `node:22-slim`.

Previously:

- When a **non-root leaf node** split, the new leaf nodes were written via `writeNodeToDisk` without allocated disk blocks, causing:

```
could not convert extents into tree: block number not found for node
```

- When leaf splits increased the number of children under the **inode-root internal node** past its 4-entry limit, serialization could panic (`slice bounds out of range`) because the over-capacity root was never split.

This change:

- Allocates disk blocks and uses `writeNodeToBlock` when splitting non-root leaf nodes (consistent with the existing root-split path)
- Splits the inode-root internal node via `splitInternalNodeChildren` when child count exceeds `max`
- Applies the same explicit block allocation to non-root internal node splits
- Adds regression tests for non-root leaf split, inode-root internal overflow, and an ~80 MiB chunked write scenario

## Root cause

`writeNodeToDisk` resolves a node's disk block by looking it up in `parent.children`. Nodes created during a split are not yet registered there, so the lookup fails. Root splits already avoided this by allocating blocks explicitly; non-root splits did not.

When a leaf split replaced one child with two under the inode-root internal node, the root could exceed its 4-child limit without being split, producing an invalid tree.

## Test plan

- [x] `go test ./filesystem/ext4/ -run '^TestExtendExtentTree' -count=1`
- [x] Verified pre-fix code fails at `fileBlock 340` with `block number not found for node`