### PR TITLE
squashfs: handle images with no fragment or xattr table

### DIFF
--- a/filesystem/squashfs/directoryentry_internal_test.go
+++ b/filesystem/squashfs/directoryentry_internal_test.go
@@ -48,3 +48,25 @@ func TestDirectoryEntry(t *testing.T) {
 		t.Errorf("Expected InodeType %q for nil inode, got %q", "unknown", st.InodeType)
 	}
 }
+
+// TestDirectoryEntryFromInodeNilXattrTable checks that an inode advertising an
+// xattr index does not panic when the image has no xattr table. squashfs-tools-ng
+// sets the NO_XATTRS superblock flag (so fs.xattrs is nil) yet can leave a
+// non-sentinel xattr index in an inode. Regression test for rclone/rclone#9004.
+func TestDirectoryEntryFromInodeNilXattrTable(t *testing.T) {
+	fs := &FileSystem{xattrs: nil, uidsGids: []uint32{1000}}
+	in := &inodeImpl{
+		header: &inodeHeader{inodeType: inodeExtendedDirectory, mode: 0o755},
+		body:   extendedDirectory{xAttrIndex: 0}, // 0 != noXattrInodeFlag => has == true
+	}
+	entry, err := fs.directoryEntryFromInode("subdir", in, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry == nil || entry.name != "subdir" {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+	if len(entry.xattrs) != 0 {
+		t.Fatalf("expected no xattrs, got %v", entry.xattrs)
+	}
+}

--- a/filesystem/squashfs/fragment_internal_test.go
+++ b/filesystem/squashfs/fragment_internal_test.go
@@ -48,3 +48,19 @@ func TestFragmentEntryToBytes(t *testing.T) {
 		}
 	}
 }
+
+// TestReadFragmentTableNoFragments checks that an image with no fragments does
+// not attempt to read a (non-existent) fragment table. fragmentTableStart holds
+// the 0xffff... sentinel in that case, so reading it seeks to offset -1.
+// Regression test for reading squashfs-tools-ng images (rclone/rclone#9004).
+func TestReadFragmentTableNoFragments(t *testing.T) {
+	s := &superblock{fragmentCount: 0, fragmentTableStart: 0xffff_ffff_ffff_ffff}
+	// A nil file guarantees the test fails loudly if the code tries to read.
+	frags, err := readFragmentTable(s, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(frags) != 0 {
+		t.Fatalf("expected no fragments, got %d", len(frags))
+	}
+}

--- a/filesystem/squashfs/squashfs.go
+++ b/filesystem/squashfs/squashfs.go
@@ -632,7 +632,11 @@ func (fs *FileSystem) directoryEntryFromInode(name string, in inode, isSubdirect
 	body, header := in.getBody(), in.getHeader()
 	xattrIndex, has := body.xattrIndex()
 	xattrs := map[string]string{}
-	if has {
+	// An inode may advertise an xattr index even though the image was written
+	// without an xattr table (e.g. squashfs-tools-ng sets the NO_XATTRS superblock
+	// flag but leaves a non-sentinel index in the inode). fs.xattrs is nil in that
+	// case, so guard against it rather than dereferencing a nil table.
+	if has && fs.xattrs != nil {
 		var err error
 		xattrs, err = fs.xattrs.find(int(xattrIndex))
 		if err != nil {
@@ -798,6 +802,14 @@ func validateBlocksize(blocksize int64) error {
 }
 
 func readFragmentTable(s *superblock, file backend.File, c Compressor) ([]*fragmentEntry, error) {
+	// if there are no fragments there is no fragment table to read. In that case
+	// fragmentTableStart holds the 0xffff... "not present" sentinel, so reading it
+	// would seek to a negative offset (int64(0xffff...) == -1). Images written
+	// without tail-end packing (e.g. squashfs-tools-ng with -no-tail-packing, or a
+	// single empty directory) hit this.
+	if s.fragmentCount == 0 {
+		return nil, nil
+	}
 	// get the first level index, which is just the pointers to the fragment table metadata blocks
 	blockCount := s.fragmentCount / 512
 	if s.fragmentCount%512 > 0 {


### PR DESCRIPTION
## Problem

The squashfs reader fails on valid images written by [squashfs-tools-ng](https://github.com/AgentD/squashfs-tools-ng) that omit optional tables. Two independent failures, both reproducible with a minimal image (`gensquashfs -D <empty-dir> out.sqfs`):

- **No fragment table** (`fragmentCount == 0`): `readFragmentTable` reads unconditionally, but `fragmentTableStart` holds the `0xffffffffffffffff` "not present" sentinel, so `ReadAt` seeks to offset `-1` and fails with `error reading fragment table index: invalid seek position`.
- **No xattr table** (`NO_XATTRS` flag): `directoryEntryFromInode` calls `fs.xattrs.find(...)` when an inode advertises an xattr index, but `fs.xattrs` is `nil`, causing a **nil-pointer panic** in `(*xAttrTable).find` (`xattr.go:46`).

## Fix

Two guards, mirroring the "absent optional table" handling already done when the superblock is parsed (`!s.noXattrs && s.xattrTableStart != 0xffffffffffffffff`):

- skip reading the fragment table when `fragmentCount == 0`;
- skip the xattr lookup when `fs.xattrs == nil`.

## Tests

Added two internal regression tests (`TestReadFragmentTableNoFragments` and `TestDirectoryEntryFromInodeNilXattrTable`), both failing before / passing after. Full `filesystem/squashfs` suite passes and `go vet` is clean.

Verified end-to-end through rclone's `archive` backend (which uses this reader): the two images from [rclone/rclone#9004](https://github.com/rclone/rclone/issues/9004) that previously errored / panicked (a single empty directory, and a real squashfs-tools-ng Windows image) now list correctly.
