### PR TITLE
ext4: fix wrong span for an internal node's last child

### DIFF
--- a/filesystem/ext4/extent.go
+++ b/filesystem/ext4/extent.go
@@ -223,7 +223,7 @@ func (e extentInternalNode) findBlocks(start, count uint64, fs *FileSystem) ([]u
 		if err != nil {
 			return nil, err
 		}
-		ebf, err := parseExtents(b, e.blockSize, uint32(extentStart), uint32(extentEnd))
+		ebf, err := parseExtents(b, e.blockSize, uint32(extentStart), child.count)
 		if err != nil {
 			return nil, err
 		}
@@ -250,7 +250,7 @@ func (e extentInternalNode) blocks(fs *FileSystem) (extents, error) {
 		if err != nil {
 			return nil, err
 		}
-		ebf, err := parseExtents(b, e.blockSize, child.fileBlock, child.fileBlock+child.count-1)
+		ebf, err := parseExtents(b, e.blockSize, child.fileBlock, child.count)
 		if err != nil {
 			return nil, err
 		}
@@ -304,7 +304,11 @@ func (e *extentInternalNode) getCount() uint32 {
 // parseExtents takes bytes, parses them to find the actual extents or the next blocks down.
 // It does not recurse down the tree, as we do not want to do that until we actually are ready
 // to read those blocks. This is similar to how ext4 driver in the Linux kernel does it.
-// totalBlocks is the total number of blocks covered in this given section of the extent tree.
+// start and count describe the file-block range of this section: start is the first
+// file block, count is the number of file blocks covered (not an end block). Real ext4
+// index entries store no span for their last entry, so its span is derived here as
+// start+count; passing an end value (e.g. start+count-1) silently drops that entry's
+// last block.
 func parseExtents(b []byte, blocksize, start, count uint32) (extentBlockFinder, error) {
 	var ret extentBlockFinder
 	// must have at least header and one entry

--- a/filesystem/ext4/extent_test.go
+++ b/filesystem/ext4/extent_test.go
@@ -881,6 +881,90 @@ func TestExtendExtentTreeSplitRegression(t *testing.T) {
 	})
 }
 
+// TestExtentInternalNodeFindBlocksAcrossChildren guards the last-child span
+// bug documented on parseExtents: it builds a disk-backed tree by hand,
+//
+//	root (in memory, depth 2) -> internal node A on disk (depth 1)
+//	                                 -> leaf B (file blocks 0-4, 5 blocks)
+//	                                 -> leaf C (file blocks 5-11, 7 blocks, LAST child)
+//
+// findBlocks(0, 12, fs) must return all 12 blocks; the bug dropped the final
+// block of leaf C.
+func TestExtentInternalNodeFindBlocksAcrossChildren(t *testing.T) {
+	// 600 MiB gets 4 KiB blocks (see setupWritableExtentFS), matching the
+	// max:340 entries used below (12 + 12*340 = 4092 bytes/node).
+	fs, _ := setupWritableExtentFS(t, 600*MB)
+	blockSize := fs.superblock.blockSize
+
+	allocBlock := func(t *testing.T) uint64 {
+		t.Helper()
+		alloc, err := fs.allocateExtents(uint64(blockSize), nil)
+		if err != nil || alloc == nil || len(*alloc) == 0 {
+			t.Fatalf("allocateExtents failed: %v", err)
+		}
+		return (*alloc)[0].startingBlock
+	}
+
+	blockA := allocBlock(t)
+	blockB := allocBlock(t)
+	blockC := allocBlock(t)
+
+	leafB := extentLeafNode{
+		extentNodeHeader: extentNodeHeader{depth: 0, entries: 1, max: 340, blockSize: blockSize},
+		extents:          extents{{fileBlock: 0, count: 5, startingBlock: 1000}},
+	}
+	leafC := extentLeafNode{
+		extentNodeHeader: extentNodeHeader{depth: 0, entries: 1, max: 340, blockSize: blockSize},
+		extents:          extents{{fileBlock: 5, count: 7, startingBlock: 2000}},
+	}
+	internalA := extentInternalNode{
+		extentNodeHeader: extentNodeHeader{depth: 1, entries: 2, max: 340, blockSize: blockSize},
+		children: []*extentChildPtr{
+			{fileBlock: 0, diskBlock: blockB},
+			{fileBlock: 5, diskBlock: blockC}, // last child: span must come from caller-supplied count
+		},
+	}
+
+	if err := writeNodeToBlock(&leafB, fs, blockB); err != nil {
+		t.Fatalf("writeNodeToBlock(leafB): %v", err)
+	}
+	if err := writeNodeToBlock(&leafC, fs, blockC); err != nil {
+		t.Fatalf("writeNodeToBlock(leafC): %v", err)
+	}
+	if err := writeNodeToBlock(&internalA, fs, blockA); err != nil {
+		t.Fatalf("writeNodeToBlock(internalA): %v", err)
+	}
+
+	root := extentInternalNode{
+		extentNodeHeader: extentNodeHeader{depth: 2, entries: 1, max: 4, blockSize: blockSize},
+		children: []*extentChildPtr{
+			{fileBlock: 0, count: 12, diskBlock: blockA},
+		},
+	}
+
+	got, err := root.findBlocks(0, 12, fs)
+	if err != nil {
+		t.Fatalf("findBlocks failed: %v", err)
+	}
+
+	var want []uint64
+	for i := uint64(0); i < 5; i++ {
+		want = append(want, 1000+i)
+	}
+	for i := uint64(0); i < 7; i++ {
+		want = append(want, 2000+i)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("findBlocks returned %d blocks, want %d: got %v, want %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("block[%d] = %d, want %d (full: got %v, want %v)", i, got[i], want[i], got, want)
+		}
+	}
+}
+
 // TestExtendExtentTreeLargeFile reproduces the original OCI flatten
 // failure: writing a large binary in small chunks fragments allocations
 // across hundreds of extents and forces the extent tree to grow through


### PR DESCRIPTION
extentInternalNode.findBlocks and .blocks() called parseExtents with an inclusive end block in its count argument, but parseExtents' internal-node branch treats that argument as an actual count (start+count marks one past the end) when deriving the span of a node's last child -- real ext4 index entries don't store a count on disk, so the last entry's span has to come from the caller. The mismatch silently dropped the final file block of any range reaching the last child of a node loaded this way.

.blocks() reads were unaffected in practice: leaf-node parsing ignores the start/count arguments entirely, so a wrong count only mattered when it was also passed down to a child's own findBlocks call. findBlocks itself isn't wired up to any current caller, so this had no observable effect until something exercises it directly (e.g. a range read added on top of the existing full-file read path).

Pass the child's actual count instead of computing an end block, matching the one caller (loadChildNode) that already did this correctly.