### PR TITLE
ext4: stop discarding the cause of directory read failures

### DIFF
--- a/filesystem/ext4/ext4.go
+++ b/filesystem/ext4/ext4.go
@@ -1807,7 +1807,7 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, error
 	}
 	entries, err := fs.readDirectory(rootInode)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read directory %s: %v", "/", err)
+		return nil, fmt.Errorf("failed to read directory %s: %w", "/", err)
 	}
 	currentDir.entries = entries
 	for i, subp := range paths {
@@ -1835,7 +1835,7 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, error
 				var subdirEntry *directoryEntry
 				subdirEntry, err = fs.mkSubdir(currentDir, subp)
 				if err != nil {
-					return nil, fmt.Errorf("failed to create subdirectory %s", "/"+strings.Join(paths[0:i+1], "/"))
+					return nil, fmt.Errorf("failed to create subdirectory %s: %w", "/"+strings.Join(paths[0:i+1], "/"), err)
 				}
 				// save where we are to search next
 				currentDir = &Directory{
@@ -1848,7 +1848,7 @@ func (fs *FileSystem) readDirWithMkdir(p string, doMake bool) (*Directory, error
 		// get all of the entries in this directory
 		entries, err = fs.readDirectory(currentDir.inode)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read directory %s", "/"+strings.Join(paths[0:i+1], "/"))
+			return nil, fmt.Errorf("failed to read directory %s: %w", "/"+strings.Join(paths[0:i+1], "/"), err)
 		}
 		currentDir.entries = entries
 	}


### PR DESCRIPTION
readDirWithMkdir's per-level readDirectory call dropped its error entirely, collapsing every possible cause -- checksum mismatches, unparseable dirents, htree rejections, extent tree failures, inode read failures -- into a single opaque "failed to read directory <path>" with no detail at all. The mkSubdir wrapper a few lines above had the same problem. The root-level readDirectory call did include the error text (%v), but not in a form errors.Is/errors.As can reach.

Wrap all three with %w so the real cause survives to the caller.