### PR TITLE
ext4: accept non-zero padding bytes in HTree dot/dotdot names

### DIFF
--- a/filesystem/ext4/directory.go
+++ b/filesystem/ext4/directory.go
@@ -144,7 +144,7 @@ func parseDirectoryTreeRoot(b []byte, largeDir bool) (node *directoryHashRoot, e
 	// Only check the meaningful name bytes (name_len=1); padding bytes beyond
 	// that are not guaranteed to be zero by the ext4 spec.
 	if b[0x8] != '.' {
-		return nil, fmt.Errorf("directory hash tree root dot name is %s and not '.'", b[0x8:0x9])
+		return nil, fmt.Errorf("directory hash tree root dot name is %q and not '.'", b[0x8:0x9])
 	}
 
 	// dotdot parameters
@@ -159,7 +159,7 @@ func parseDirectoryTreeRoot(b []byte, largeDir bool) (node *directoryHashRoot, e
 	}
 	// Same: only check name_len=2 bytes; padding is not guaranteed to be zero.
 	if b[0x14] != '.' || b[0x15] != '.' {
-		return nil, fmt.Errorf("directory hash tree root dotdot name is %s and not '..'", b[0x14:0x16])
+		return nil, fmt.Errorf("directory hash tree root dotdot name is %q and not '..'", b[0x14:0x16])
 	}
 
 	treeInformation := b[0x1d]

--- a/filesystem/ext4/directory.go
+++ b/filesystem/ext4/directory.go
@@ -1,7 +1,6 @@
 package ext4
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 )
@@ -142,9 +141,10 @@ func parseDirectoryTreeRoot(b []byte, largeDir bool) (node *directoryHashRoot, e
 	if dotFileType != dirFileTypeDirectory {
 		return nil, fmt.Errorf("directory hash tree root dot file type is %d and not %v", dotFileType, dirFileTypeDirectory)
 	}
-	dotName := b[0x8:0xc]
-	if !bytes.Equal(dotName, []byte{'.', 0, 0, 0}) {
-		return nil, fmt.Errorf("directory hash tree root dot name is %s and not '.'", dotName)
+	// Only check the meaningful name bytes (name_len=1); padding bytes beyond
+	// that are not guaranteed to be zero by the ext4 spec.
+	if b[0x8] != '.' {
+		return nil, fmt.Errorf("directory hash tree root dot name is %s and not '.'", b[0x8:0x9])
 	}
 
 	// dotdot parameters
@@ -157,9 +157,9 @@ func parseDirectoryTreeRoot(b []byte, largeDir bool) (node *directoryHashRoot, e
 	if dotdotFileType != dirFileTypeDirectory {
 		return nil, fmt.Errorf("directory hash tree root dotdot file type is %d and not %v", dotdotFileType, dirFileTypeDirectory)
 	}
-	dotdotName := b[0x14:0x18]
-	if !bytes.Equal(dotdotName, []byte{'.', '.', 0, 0}) {
-		return nil, fmt.Errorf("directory hash tree root dotdot name is %s and not '..'", dotdotName)
+	// Same: only check name_len=2 bytes; padding is not guaranteed to be zero.
+	if b[0x14] != '.' || b[0x15] != '.' {
+		return nil, fmt.Errorf("directory hash tree root dotdot name is %s and not '..'", b[0x14:0x16])
 	}
 
 	treeInformation := b[0x1d]


### PR DESCRIPTION
parseDirectoryTreeRoot validated the full 4-byte name fields of the "." and ".." directory entries against ['.', 0, 0, 0] / ['.', '.', 0, 0]. The ext4 spec only guarantees that the first name_len bytes are meaningful; the trailing padding bytes may be non-zero and the Linux kernel does not check them.

The strict check broke ReadDir on any HTree-indexed directory whose block happened to contain non-zero padding, e.g. a large __pycache__ directory where bytes 0xa–0xb of the dot entry were observed as '/' (0x2f) and 'a' (0x61).

Fix both checks to compare only the first name_len bytes and remove the now-unused bytes import.